### PR TITLE
Update docker-compose.yml

### DIFF
--- a/run_sgx/docker-compose.yml
+++ b/run_sgx/docker-compose.yml
@@ -21,5 +21,5 @@ services:
     restart: unless-stopped
     command: -s -y -d
     healthcheck:
-      test: ["CMD", "ls /dev/isg /dev/mei0"]
+      test: ["CMD", "ls", "/dev/isgx", "/dev/mei0"]
 


### PR DESCRIPTION
CMD splitting required in healthcheck test. 
Fixes unhealthy status
Also `/dev/isg` typo caused some confusion.  Healthcheck devices should always match device names provided above.