### PR TITLE
SKALE-2835 fix bls key share naming, remove redundant function

### DIFF
--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -654,8 +654,7 @@ Json::Value SGXWalletServer::deleteBlsKeyImpl(const std::string& name) {
         if (!checkName(name, "BLS_KEY")) {
             throw SGXException(INVALID_BLS_NAME, "Invalid BLSKey name format");
         }
-        std::string key = "BLSKEYSHARE:" + name;
-        std::shared_ptr <std::string> bls_ptr = LevelDB::getLevelDb()->readString(key);
+        std::shared_ptr <std::string> bls_ptr = LevelDB::getLevelDb()->readString(name);
 
         if (bls_ptr != nullptr) {
             LevelDB::getLevelDb()->deleteKey(name);
@@ -781,16 +780,6 @@ shared_ptr <string> SGXWalletServer::readFromDb(const string &name, const string
     }
 
     return dataStr;
-}
-
-shared_ptr <string> SGXWalletServer::readKeyShare(const string &_keyShareName) {
-    auto keyShareStr = LevelDB::getLevelDb()->readString("BLSKEYSHARE:" + _keyShareName);
-
-    if (keyShareStr == nullptr) {
-        throw SGXException(KEY_SHARE_DOES_NOT_EXIST, "Key share with this name does not exist");
-    }
-
-    return keyShareStr;
 }
 
 void SGXWalletServer::writeKeyShare(const string &_keyShareName, const string &_value, int _index, int _n, int _t) {

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -783,23 +783,11 @@ shared_ptr <string> SGXWalletServer::readFromDb(const string &name, const string
 }
 
 void SGXWalletServer::writeKeyShare(const string &_keyShareName, const string &_value, int _index, int _n, int _t) {
-    Json::Value val;
-    Json::FastWriter writer;
-
-    val["value"] = _value;
-    val["t"] = _t;
-    val["index"] = _index;
-    val["n'"] = _n;
-
-    string json = writer.write(val);
-
-    auto key = "BLSKEYSHARE:" + _keyShareName;
-
     if (LevelDB::getLevelDb()->readString(_keyShareName) != nullptr) {
         throw SGXException(KEY_SHARE_ALREADY_EXISTS, "Key share with this name already exists");
     }
 
-    LevelDB::getLevelDb()->writeString(key, _value);
+    LevelDB::getLevelDb()->writeString(_keyShareName, _value);
 }
 
 void SGXWalletServer::writeDataToDB(const string &Name, const string &value) {

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -105,8 +105,6 @@ public:
 
     static void writeKeyShare(const string &_keyShareName, const string &_value, int _index, int _n, int _t);
 
-    static shared_ptr<string> readKeyShare(const string &_keyShare);
-
     static Json::Value
     importBLSKeyShareImpl(const string &_keyShare, const string &_keyShareName, int t, int n, int _index);
 


### PR DESCRIPTION
low risk
fix incorrect naming, remove unused function