### PR TITLE
Fix levelDB memory leak

### DIFF
--- a/LevelDB.cpp
+++ b/LevelDB.cpp
@@ -128,7 +128,7 @@ uint64_t LevelDB::visitKeys(LevelDB::KeyVisitor *_visitor,
 
   uint64_t readCounter = 0;
 
-  shared_ptr<leveldb::Iterator> it(db->NewIterator(readOptions));
+  unique_ptr<leveldb::Iterator> it(db->NewIterator(readOptions));
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     _visitor->visitDBKey(it->key().data());
     readCounter++;
@@ -144,7 +144,7 @@ std::vector<string> LevelDB::writeKeysToVector1(uint64_t _maxKeysToVisit) {
   uint64_t readCounter = 0;
   std::vector<string> keys;
 
-  shared_ptr<leveldb::Iterator> it(db->NewIterator(readOptions));
+  unique_ptr<leveldb::Iterator> it(db->NewIterator(readOptions));
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     string cur_key(it->key().data(), it->key().size());
     keys.push_back(cur_key);
@@ -170,7 +170,7 @@ void LevelDB::writeDataUnique(const string &name, const string &value) {
 pair<stringstream, uint64_t> LevelDB::getAllKeys() {
   stringstream keysInfo;
 
-  leveldb::Iterator *it = db->NewIterator(readOptions);
+  unique_ptr<leveldb::Iterator> it(db->NewIterator(readOptions));
   uint64_t counter = 0;
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     ++counter;
@@ -197,7 +197,7 @@ pair<stringstream, uint64_t> LevelDB::getAllKeys() {
 }
 
 pair<string, uint64_t> LevelDB::getLatestCreatedKey() {
-  leveldb::Iterator *it = db->NewIterator(readOptions);
+  unique_ptr<leveldb::Iterator> it(db->NewIterator(readOptions));
 
   int64_t latest_timestamp = 0;
   string latest_created_key_name = "";
@@ -226,13 +226,16 @@ LevelDB::LevelDB(string &filename) {
   leveldb::Options options;
   options.create_if_missing = true;
 
-  if (!leveldb::DB::Open(options, filename, (leveldb::DB **)&db).ok()) {
+  leveldb::DB *raw_db = nullptr;
+  if (!leveldb::DB::Open(options, filename, &raw_db).ok()) {
     throw std::runtime_error("Unable to open levelDB database");
   }
 
-  if (db == nullptr) {
+  if (raw_db == nullptr) {
     throw std::runtime_error("Null levelDB object");
   }
+
+  db = shared_ptr<leveldb::DB>(raw_db);
 }
 
 LevelDB::~LevelDB() {}

--- a/testw.cpp
+++ b/testw.cpp
@@ -77,9 +77,7 @@ public:
     initAll(L_INFO, false, false, true, false, true);
   }
 
-  ~TestFixture() {
-    TestUtils::destroyEnclave();
-  }
+  ~TestFixture() { TestUtils::destroyEnclave(); }
 };
 
 class TestFixtureHTTPS {
@@ -90,9 +88,7 @@ public:
     initAll(L_INFO, false, true, true, false, true);
   }
 
-  ~TestFixtureHTTPS() {
-    TestUtils::destroyEnclave();
-  }
+  ~TestFixtureHTTPS() { TestUtils::destroyEnclave(); }
 };
 
 class TestFixtureZMQSign {
@@ -103,9 +99,7 @@ public:
     initAll(L_INFO, false, true, true, false, false);
   }
 
-  ~TestFixtureZMQSign() {
-    TestUtils::destroyEnclave();
-  }
+  ~TestFixtureZMQSign() { TestUtils::destroyEnclave(); }
 };
 
 class TestFixtureNoResetFromBackup {
@@ -128,9 +122,7 @@ public:
     initAll(L_INFO, false, false, true, false, true);
   }
 
-  ~TestFixtureNoReset() {
-    TestUtils::destroyEnclave();
-  }
+  ~TestFixtureNoReset() { TestUtils::destroyEnclave(); }
 };
 
 TEST_CASE_METHOD(TestFixture, "ECDSA AES keygen and signature test",

--- a/testw.cpp
+++ b/testw.cpp
@@ -78,7 +78,6 @@ public:
   }
 
   ~TestFixture() {
-    //        ZMQServer::exitZMQServer();
     TestUtils::destroyEnclave();
   }
 };
@@ -92,7 +91,6 @@ public:
   }
 
   ~TestFixtureHTTPS() {
-    //        ZMQServer::exitZMQServer();
     TestUtils::destroyEnclave();
   }
 };
@@ -106,7 +104,6 @@ public:
   }
 
   ~TestFixtureZMQSign() {
-    //        ZMQServer::exitZMQServer();
     TestUtils::destroyEnclave();
   }
 };
@@ -120,7 +117,6 @@ public:
 
   ~TestFixtureNoResetFromBackup() {
     sleep(3);
-    //        ZMQServer::exitZMQServer();
     TestUtils::destroyEnclave();
   }
 };
@@ -133,7 +129,6 @@ public:
   }
 
   ~TestFixtureNoReset() {
-    //        ZMQServer::exitZMQServer();
     TestUtils::destroyEnclave();
   }
 };


### PR DESCRIPTION
### Description

- Improved pointer handling:
    - Using unique_ptr whenever best suited instead of shared_ptr or raw pointers
- Removal of dangerous cast from shared_ptr to native C pointer (**main reason for the memory leaks**)

- Solved all levelDB related memory leaks

### Tests
- No changes

### Performance
- No impact

Fixes #457
  