### PR TITLE
Switch getDecryptionShares log to trace level

### DIFF
--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -1097,7 +1097,7 @@ SGXWalletServer::generateBLSPrivateKeyImpl(const string &blsKeyName) {
 
 Json::Value SGXWalletServer::getDecryptionSharesImpl(
     const std::string &blsKeyName, const Json::Value &publicDecryptionValues) {
-  spdlog::info("Entering {}", __FUNCTION__);
+  spdlog::debug("Entering {}", __FUNCTION__);
   INIT_RESULT(result)
 
   try {

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -1097,7 +1097,7 @@ SGXWalletServer::generateBLSPrivateKeyImpl(const string &blsKeyName) {
 
 Json::Value SGXWalletServer::getDecryptionSharesImpl(
     const std::string &blsKeyName, const Json::Value &publicDecryptionValues) {
-  spdlog::debug("Entering {}", __FUNCTION__);
+  spdlog::trace("Entering {}", __FUNCTION__);
   INIT_RESULT(result)
 
   try {

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -20,4 +20,4 @@ To run an individual test named `[test_ex]`:
 ./testw [test_ex]
 ```
 
-We follow the convention of naming tests like `[test-name}]`.
+We follow the convention of naming tests like `[test-name]`.


### PR DESCRIPTION
### Description

- Changed log from info to trace level

### Tests

Tested locally - no logs show up for this call

### Performance

Should not be impacted

Fixes #464 