### PR TITLE
Intra-request parallelization for `getDecryptionShares`

### DIFF
--- a/DockerfileBase
+++ b/DockerfileBase
@@ -1,32 +1,7 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install software-properties-common -y && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get update && apt-get install -y \
-    build-essential \
-    ocaml \
-    ocamlbuild \
-    automake \
-    autoconf \
-    libtool \
-    wget \
-    python-is-python3 \
-    libssl-dev \
-    git \
-    cmake \
-    perl \
-    libcurl4-openssl-dev \
-    protobuf-compiler \
-    libprotobuf-dev \
-    debhelper \
-    reprepro \
-    unzip \
-    pkgconf \
-    libboost-dev \
-    libboost-system-dev \
-    libboost-thread-dev \
-    lsb-release \
-    libsystemd0
+COPY scripts/install_packages.sh /install_packages.sh
+RUN chmod +x /install_packages.sh && /install_packages.sh
 
 RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
     dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb

--- a/Makefile.am
+++ b/Makefile.am
@@ -110,7 +110,7 @@ sgxwallet_LDADD=-l$(SGX_URTS_LIB) -l$(SGX_UAE_SERVICE_LIB) -LlibBLS/deps/deps_in
    -l:libff.a -lgmp -ldl -l:libsgx_capable.a -l:libsgx_tprotected_fs.a \
    -l:libzmq.a \
    -ljsonrpccpp-stub -ljsonrpccpp-server -ljsonrpccpp-client -ljsonrpccpp-common -ljsoncpp -lmicrohttpd \
-   -lboost_system -lboost_thread -lgnutls -lgcrypt -lidn2 -lcurl -lssl -lcrypto -lz -lpthread -lstdc++fs
+   -lboost_system -lboost_thread -ltbb -lgnutls -lgcrypt -lidn2 -lcurl -lssl -lcrypto -lz -lpthread -lstdc++fs
 
 testw_SOURCES=testw.cpp $(COMMON_SRC)
 nodist_testw_SOURCES=${nodist_sgxwallet_SOURCES}
@@ -127,4 +127,4 @@ sgx_util_LDADD=-LlibBLS/deps/deps_inst/x86_or_x64/lib -Lleveldb/build -LlibBLS/b
                    -l:libzmq.a \
                    -l:libbls.a -l:libleveldb.a \
                    -l:libff.a -lgmp -ljsonrpccpp-stub -ljsonrpccpp-server -ljsonrpccpp-client -ljsonrpccpp-common \
-                   -ljsoncpp -lmicrohttpd -lgnutls -lgcrypt -lidn2 -lcurl -lssl -lcrypto -lz -lpthread -ldl
+                   -ljsoncpp -ltbb -lmicrohttpd -lgnutls -lgcrypt -lidn2 -lcurl -lssl -lcrypto -lz -lpthread -ldl

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -28,9 +28,9 @@
 #include "abstractstubserver.h"
 #include <algorithm>
 #include <jsonrpccpp/server/connectors/httpserver.h>
-#include <tbb/task_group.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <tbb/task_group.h>
 #include <unistd.h>
 
 #include "sgxwallet.h"
@@ -177,7 +177,7 @@ void SGXWalletServer::createCertsIfNeeded() {
 }
 
 void SGXWalletServer::initThreadPool(size_t _numThreads) {
-    threadPool.initialize(_numThreads);
+  threadPool.initialize(_numThreads);
 }
 
 void SGXWalletServer::initHttpsServer(bool _checkCerts) {
@@ -1111,7 +1111,7 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
     CHECK_STATE(checkName(blsKeyName, "BLS_KEY"));
     CHECK_STATE(publicDecryptionValues.isArray());
     CHECK_STATE(publicDecryptionValues.size() <= INT_MAX);
-    
+
     shared_ptr<string> encryptedKeyHex_ptr = readFromDb(blsKeyName);
     CHECK_STATE(encryptedKeyHex_ptr != nullptr);
 
@@ -1124,8 +1124,7 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
     if (threadBatch == 0) {
       threadBatch = 1;
       numThreads = batchSize;
-    }
-    else {
+    } else {
       threadRemainder = batchSize % threadPool.size;
     }
 
@@ -1173,12 +1172,13 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
           int startingIdx = startIndices[i];
           int endingIdx = endIndices[i];
           for (int j = startingIdx; j < endingIdx; ++j) {
-            
+
             if (j >= batchSize) {
               batchSizeError.store(true);
               return;
             }
-            std::string publicDecryptionValue = publicDecryptionValues[j].asString();
+            std::string publicDecryptionValue =
+                publicDecryptionValues[j].asString();
             if (publicDecryptionValue.length() != CIPHERTEXT_CHARACTER_LENGTH) {
               shareSizeError.store(true);
               return;
@@ -1198,7 +1198,8 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
     //                  Execute decryption
     // -----------------------------------------------------------
     // holds results for each thread
-    std::vector<std::pair<std::vector<std::string>, std::vector<int>>> decryptionSharesByThread(numThreads);
+    std::vector<std::pair<std::vector<std::string>, std::vector<int>>>
+        decryptionSharesByThread(numThreads);
 
     // compute decryption shares in parallel
     threadPool.execute([&]() {
@@ -1208,8 +1209,7 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
         // pass 'i' by copy to each thread
         group.run([&, i]() {
           decryptionSharesByThread[i] = calculateDecryptionShares(
-              encryptedKeyHex_ptr->c_str(),
-              concatenatedCiphertexts[i]);
+              encryptedKeyHex_ptr->c_str(), concatenatedCiphertexts[i]);
         });
       }
       group.wait(); // wait for all threads to finish

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -179,13 +179,13 @@ void SGXWalletServer::createCertsIfNeeded() {
 }
 
 void SGXWalletServer::initThreadPool(size_t _numThreads) {
-  if (!globalSGXThreadpoolControl) {
+  static atomic_bool threadPoolInited(false);
+  if (!threadPoolInited.exchange(true)) {
     // Set global max threads once
     globalSGXThreadpoolControl = std::make_unique<tbb::global_control>(
         tbb::global_control::max_allowed_parallelism, _numThreads);
+    threadPool.initialize(_numThreads);
   }
-
-  threadPool.initialize(_numThreads);
 }
 
 void SGXWalletServer::initHttpsServer(bool _checkCerts) {
@@ -1122,6 +1122,7 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
 
     shared_ptr<string> encryptedKeyHex_ptr = readFromDb(blsKeyName);
     CHECK_STATE(encryptedKeyHex_ptr != nullptr);
+    CHECK_STATE(threadPool.isInitialized());
 
     int batchSize = publicDecryptionValues.size();
     int threadBatch = batchSize / threadPool.size;
@@ -1139,25 +1140,25 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
     // -----------------------------------------------------------
     //      Populate start and end indices for each thread
     // -----------------------------------------------------------
-    std::array<int, DEFAULT_NUM_THREADS_SGX> startIndices;
-    std::array<int, DEFAULT_NUM_THREADS_SGX> endIndices;
+    std::vector<int> startIndices(numThreads);
+    std::vector<int> endIndices(numThreads);
 
     int thread = 0;
     int startIdx = 0;
     int plusOneBatch = threadBatch + 1;
     // populate the threads that will have +1 items
     while (threadRemainder > 0) {
-      startIndices[thread] = startIdx;
+      startIndices.at(thread) = startIdx;
       startIdx += plusOneBatch;
-      endIndices[thread] = startIdx;
+      endIndices.at(thread) = startIdx;
       ++thread;
       --threadRemainder;
     }
     // populate the rest
     while (thread < numThreads) {
-      startIndices[thread] = startIdx;
+      startIndices.at(thread) = startIdx;
       startIdx += threadBatch;
-      endIndices[thread] = startIdx;
+      endIndices.at(thread) = startIdx;
       ++thread;
     }
 
@@ -1177,8 +1178,8 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
         group.run([&, i]() {
           std::string local; // will hold inputs to each thread
           local.reserve(ENCLAVE_MAX_BATCH_BUFFER_SIZE);
-          int startingIdx = startIndices[i];
-          int endingIdx = endIndices[i];
+          int startingIdx = startIndices.at(i);
+          int endingIdx = endIndices.at(i);
           for (int j = startingIdx; j < endingIdx; ++j) {
 
             if (j >= batchSize) {
@@ -1193,7 +1194,7 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
             }
             local += publicDecryptionValue;
           }
-          concatenatedCiphertexts[i] = std::move(local);
+          concatenatedCiphertexts.at(i) = std::move(local);
         });
       }
       group.wait(); // wait for all threads to finish
@@ -1216,8 +1217,8 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
       for (int i = 0; i < numThreads; ++i) {
         // pass 'i' by copy to each thread
         group.run([&, i]() {
-          decryptionSharesByThread[i] = calculateDecryptionShares(
-              encryptedKeyHex_ptr->c_str(), concatenatedCiphertexts[i]);
+          decryptionSharesByThread.at(i) = calculateDecryptionShares(
+              encryptedKeyHex_ptr->c_str(), concatenatedCiphertexts.at(i));
         });
       }
       group.wait(); // wait for all threads to finish
@@ -1230,10 +1231,10 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
     for (auto &decryptionShares : decryptionSharesByThread) {
       size_t sharesAmount = decryptionShares.first.size();
       for (int i = 0; i < sharesAmount; i++) {
-        result["decryptionShares"][idx] = decryptionShares.first[i];
-        if (decryptionShares.second[i] > 0) {
+        result["decryptionShares"][idx] = decryptionShares.first.at(i);
+        if (decryptionShares.second.at(i) > 0) {
           result["failedRequests"][std::to_string(idx)] =
-              decryptionShares.second[i];
+              decryptionShares.second.at(i);
         }
         idx++;
       }

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -64,7 +64,8 @@ std::shared_timed_mutex sgxInitMutex;
 uint64_t initTime;
 
 SGXWalletServer::thread_pool SGXWalletServer::threadPool;
-std::unique_ptr<tbb::global_control> SGXWalletServer::globalSGXThreadpoolControl = nullptr;
+std::unique_ptr<tbb::global_control>
+    SGXWalletServer::globalSGXThreadpoolControl = nullptr;
 
 void setFullOptions(uint64_t _logLevel, int _useHTTPS, int _autoconfirm,
                     int _enterBackupKey) {
@@ -179,11 +180,9 @@ void SGXWalletServer::createCertsIfNeeded() {
 
 void SGXWalletServer::initThreadPool(size_t _numThreads) {
   if (!globalSGXThreadpoolControl) {
-      // Set global max threads once
-      globalSGXThreadpoolControl = std::make_unique<tbb::global_control>(
-          tbb::global_control::max_allowed_parallelism,
-          _numThreads
-      );
+    // Set global max threads once
+    globalSGXThreadpoolControl = std::make_unique<tbb::global_control>(
+        tbb::global_control::max_allowed_parallelism, _numThreads);
   }
 
   threadPool.initialize(_numThreads);

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -1129,28 +1129,74 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
       threadRemainder = batchSize % threadPool.size;
     }
 
-    // validate inputs
-    std::vector<std::string> concatenatedCiphertexts(numThreads); // will hold inputs to each thread
+    // -----------------------------------------------------------
+    //      Populate start and end indices for each thread
+    // -----------------------------------------------------------
+    std::array<int, DEFAULT_NUM_THREADS_SGX> startIndices;
+    std::array<int, DEFAULT_NUM_THREADS_SGX> endIndices;
 
-    for (size_t i = 0; i < numThreads; ++i) {
-      concatenatedCiphertexts[i].reserve(ENCLAVE_MAX_BATCH_BUFFER_SIZE);
+    int thread = 0;
+    int startIdx = 0;
+    int plusOneBatch = threadBatch + 1;
+    // populate the threads that will have +1 items
+    while (threadRemainder > 0) {
+      startIndices[thread] = startIdx;
+      startIdx += plusOneBatch;
+      endIndices[thread] = startIdx;
+      ++thread;
+      --threadRemainder;
+    }
+    // populate the rest
+    while (thread < numThreads) {
+      startIndices[thread] = startIdx;
+      startIdx += threadBatch;
+      endIndices[thread] = startIdx;
+      ++thread;
     }
 
-    int startingIdx = 0;
-    for (int i = 0; i < numThreads; ++i, --threadRemainder) {
-      // number of items for current thread
-      int count = threadBatch + ( threadRemainder > 0 ? 1 : 0 );
-      int endingIdx = std::min(startingIdx + count, batchSize);
+    // -----------------------------------------------------------
+    //                        Parse input
+    // -----------------------------------------------------------
+    std::vector<std::string> concatenatedCiphertexts(numThreads);
+    std::atomic<bool> batchSizeError(false);
+    std::atomic<bool> shareSizeError(false);
 
-      for (int j = startingIdx; j < endingIdx; ++j) {
-        CHECK_STATE(j < batchSize);
-        std::string publicDecryptionValue = publicDecryptionValues[j].asString();
-        CHECK_STATE(publicDecryptionValue.length() == CIPHERTEXT_CHARACTER_LENGTH);
-        concatenatedCiphertexts[i] += publicDecryptionValue;
+    // evaluate inputs in parallel
+    threadPool.execute([&]() {
+      tbb::task_group group;
+
+      for (int i = 0; i < numThreads; ++i) {
+        // pass 'i' by copy to each thread
+        group.run([&, i]() {
+          std::string local; // will hold inputs to each thread
+          local.reserve(ENCLAVE_MAX_BATCH_BUFFER_SIZE);
+          int startingIdx = startIndices[i];
+          int endingIdx = endIndices[i];
+          for (int j = startingIdx; j < endingIdx; ++j) {
+            
+            if (j >= batchSize) {
+              batchSizeError.store(true);
+              return;
+            }
+            std::string publicDecryptionValue = publicDecryptionValues[j].asString();
+            if (publicDecryptionValue.length() != CIPHERTEXT_CHARACTER_LENGTH) {
+              shareSizeError.store(true);
+              return;
+            }
+            local += publicDecryptionValue;
+          }
+          concatenatedCiphertexts[i] = std::move(local);
+        });
       }
-      startingIdx += count;
-    }
+      group.wait(); // wait for all threads to finish
+    });
 
+    CHECK_STATE(!batchSizeError.load());
+    CHECK_STATE(!shareSizeError.load());
+
+    // -----------------------------------------------------------
+    //                  Execute decryption
+    // -----------------------------------------------------------
     // holds results for each thread
     std::vector<std::pair<std::vector<std::string>, std::vector<int>>> decryptionSharesByThread(numThreads);
 
@@ -1169,7 +1215,9 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
       group.wait(); // wait for all threads to finish
     });
 
-    // Build response
+    // -----------------------------------------------------------
+    //                  Build Response
+    // -----------------------------------------------------------
     int idx = 0;
     for (auto &decryptionShares : decryptionSharesByThread) {
       size_t sharesAmount = decryptionShares.first.size();

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -28,6 +28,7 @@
 #include "abstractstubserver.h"
 #include <algorithm>
 #include <jsonrpccpp/server/connectors/httpserver.h>
+#include <tbb/task_group.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -61,6 +62,8 @@ using namespace std;
 std::shared_timed_mutex sgxInitMutex;
 
 uint64_t initTime;
+
+SGXWalletServer::thread_pool SGXWalletServer::threadPool;
 
 void setFullOptions(uint64_t _logLevel, int _useHTTPS, int _autoconfirm,
                     int _enterBackupKey) {
@@ -171,6 +174,10 @@ void SGXWalletServer::createCertsIfNeeded() {
     throw SGXException(FAIL_TO_VERIFY_CERTIFICATE,
                        "SERVER CERTIFICATE VERIFICATION FAILED");
   }
+}
+
+void SGXWalletServer::initThreadPool(size_t _numThreads) {
+    threadPool.initialize(_numThreads);
 }
 
 void SGXWalletServer::initHttpsServer(bool _checkCerts) {
@@ -1101,49 +1108,78 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
   INIT_RESULT(result)
 
   try {
-    if (!checkName(blsKeyName, "BLS_KEY")) {
-      throw SGXException(BLS_SIGN_INVALID_KS_NAME,
-                         string(__FUNCTION__) + ":Invalid BLSKey name");
-    }
-
-    if (!publicDecryptionValues.isArray()) {
-      throw SGXException(INVALID_DECRYPTION_VALUE_FORMAT,
-                         string(__FUNCTION__) +
-                             ":Public decryption values should be an array");
-    }
-
-    if (publicDecryptionValues.size() > INT_MAX) {
-      throw SGXException(TOO_MANY_DECRYPTION_VALUES,
-                         string(__FUNCTION__) +
-                             ":Public decryption values array is too large");
-    }
-
+    CHECK_STATE(checkName(blsKeyName, "BLS_KEY"));
+    CHECK_STATE(publicDecryptionValues.isArray());
+    CHECK_STATE(publicDecryptionValues.size() <= INT_MAX);
+    
     shared_ptr<string> encryptedKeyHex_ptr = readFromDb(blsKeyName);
+    CHECK_STATE(encryptedKeyHex_ptr != nullptr);
 
-    // validate & concatenate ciphertexts
-    std::string concatenatedCiphertexts;
-    concatenatedCiphertexts.reserve(ENCLAVE_MAX_BATCH_BUFFER_SIZE);
-    for (int i = 0; i < publicDecryptionValues.size(); ++i) {
-      std::string publicDecryptionValue = publicDecryptionValues[i].asString();
-      if (publicDecryptionValue.length() != CIPHERTEXT_CHARACTER_LENGTH) {
-        throw SGXException(INVALID_DECRYPTION_VALUE_FORMAT,
-                           string(__FUNCTION__) +
-                               ":Invalid publicDecryptionValue format");
-      }
-      concatenatedCiphertexts += publicDecryptionValue;
+    int batchSize = publicDecryptionValues.size();
+    int threadBatch = batchSize / threadPool.size;
+    int numThreads = threadPool.size;
+    int threadRemainder = 0;
+
+    // More threads than items - use one item per thread
+    if (threadBatch == 0) {
+      threadBatch = 1;
+      numThreads = batchSize;
+    }
+    else {
+      threadRemainder = batchSize % threadPool.size;
     }
 
-    std::pair<std::vector<std::string>, std::vector<int>> decryptionShares =
-        calculateDecryptionShares(encryptedKeyHex_ptr->c_str(),
-                                  concatenatedCiphertexts);
+    // validate inputs
+    std::vector<std::string> concatenatedCiphertexts(numThreads); // will hold inputs to each thread
 
-    size_t sharesAmount = decryptionShares.first.size();
+    for (size_t i = 0; i < numThreads; ++i) {
+      concatenatedCiphertexts[i].reserve(ENCLAVE_MAX_BATCH_BUFFER_SIZE);
+    }
 
-    for (int i = 0; i < sharesAmount; i++) {
-      result["decryptionShares"][i] = decryptionShares.first[i];
-      if (decryptionShares.second[i] > 0) {
-        result["failedRequests"][std::to_string(i)] =
-            decryptionShares.second[i];
+    int startingIdx = 0;
+    for (int i = 0; i < numThreads; ++i, --threadRemainder) {
+      // number of items for current thread
+      int count = threadBatch + ( threadRemainder > 0 ? 1 : 0 );
+      int endingIdx = std::min(startingIdx + count, batchSize);
+
+      for (int j = startingIdx; j < endingIdx; ++j) {
+        CHECK_STATE(j < batchSize);
+        std::string publicDecryptionValue = publicDecryptionValues[j].asString();
+        CHECK_STATE(publicDecryptionValue.length() == CIPHERTEXT_CHARACTER_LENGTH);
+        concatenatedCiphertexts[i] += publicDecryptionValue;
+      }
+      startingIdx += count;
+    }
+
+    // holds results for each thread
+    std::vector<std::pair<std::vector<std::string>, std::vector<int>>> decryptionSharesByThread(numThreads);
+
+    // compute decryption shares in parallel
+    threadPool.execute([&]() {
+      tbb::task_group group;
+
+      for (int i = 0; i < numThreads; ++i) {
+        // pass 'i' by copy to each thread
+        group.run([&, i]() {
+          decryptionSharesByThread[i] = calculateDecryptionShares(
+              encryptedKeyHex_ptr->c_str(),
+              concatenatedCiphertexts[i]);
+        });
+      }
+      group.wait(); // wait for all threads to finish
+    });
+
+    // Build response
+    int idx = 0;
+    for (auto &decryptionShares : decryptionSharesByThread) {
+      size_t sharesAmount = decryptionShares.first.size();
+      for (int i = 0; i < sharesAmount; i++) {
+        result["decryptionShares"][idx] = decryptionShares.first[i];
+        if (decryptionShares.second[i] > 0) {
+          result["failedRequests"][std::to_string(idx)] =
+              decryptionShares.second[i];
+        }
+        idx++;
       }
     }
   }

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -64,6 +64,7 @@ std::shared_timed_mutex sgxInitMutex;
 uint64_t initTime;
 
 SGXWalletServer::thread_pool SGXWalletServer::threadPool;
+std::unique_ptr<tbb::global_control> SGXWalletServer::globalSGXThreadpoolControl = nullptr;
 
 void setFullOptions(uint64_t _logLevel, int _useHTTPS, int _autoconfirm,
                     int _enterBackupKey) {
@@ -177,6 +178,14 @@ void SGXWalletServer::createCertsIfNeeded() {
 }
 
 void SGXWalletServer::initThreadPool(size_t _numThreads) {
+  if (!globalSGXThreadpoolControl) {
+      // Set global max threads once
+      globalSGXThreadpoolControl = std::make_unique<tbb::global_control>(
+          tbb::global_control::max_allowed_parallelism,
+          _numThreads
+      );
+  }
+
   threadPool.initialize(_numThreads);
 }
 

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -30,6 +30,7 @@
 #include <functional>
 #include <jsonrpccpp/server/connectors/httpserver.h>
 #include <tbb/task_arena.h>
+#include <tbb/global_control.h>
 
 #include "abstractstubserver.h"
 
@@ -40,6 +41,9 @@ using namespace std;
 #define TOSTRING(x) STRINGIFY(x)
 
 class SGXWalletServer : public AbstractStubServer {
+  // used to control number of max allowed parallel tasks
+  // Else, default policy can limit to number of CPU cores
+  static std::unique_ptr<tbb::global_control> globalSGXThreadpoolControl;
 
   // Thread pool for parallel processing of tasks
   struct thread_pool {
@@ -75,6 +79,8 @@ class SGXWalletServer : public AbstractStubServer {
                                 const string &_key, const string &_value);
 
 public:
+  /// Defines number of threads to be used by SGX on each call (for the ones with 
+  /// thread pool support)
   static const size_t DEFAULT_NUM_THREADS_SGX = 32;
 
   static bool verifyCert(string &_certFileName);

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -75,7 +75,7 @@ class SGXWalletServer : public AbstractStubServer {
                                 const string &_key, const string &_value);
 
 public:
-  static const size_t DEFAULT_NUM_THREADS_SGX = 16;
+  static const size_t DEFAULT_NUM_THREADS_SGX = 32;
 
   static bool verifyCert(string &_certFileName);
 

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -28,6 +28,7 @@
 #include "mutex"
 
 #include <jsonrpccpp/server/connectors/httpserver.h>
+#include <tbb/task_arena.h>
 
 #include "abstractstubserver.h"
 
@@ -38,6 +39,25 @@ using namespace std;
 #define TOSTRING(x) STRINGIFY(x)
 
 class SGXWalletServer : public AbstractStubServer {
+
+  // Thread pool for parallel processing of tasks
+  struct thread_pool {
+    size_t size;
+
+    void initialize(size_t _size) {
+      size = _size;
+      arena.initialize(_size);
+    }
+
+    // delegate task execution to TBB task arena
+    void execute(function<void()> task) {
+      arena.execute(task);
+    }
+
+  private:
+    tbb::task_arena arena;
+  };
+
   static shared_ptr<SGXWalletServer> server;
   static shared_ptr<HttpServer> httpServer;
 
@@ -45,6 +65,13 @@ class SGXWalletServer : public AbstractStubServer {
   static recursive_mutex blsRequestsLock;
   static map<string, string> ecdsaRequests;
   static recursive_mutex ecdsaRequestsLock;
+
+  // Task arena for parallel processing
+  // Can be used by each of SGXWalletServer calls to create tasks
+  // to be executed in parallel by this thread pool
+  // Must be initialized before any calls to the server
+  static thread_pool threadPool;
+  
 
   static void checkForDuplicate(map<string, string> &_map, recursive_mutex &_m,
                                 const string &_key, const string &_value);
@@ -227,6 +254,11 @@ public:
   static void initHttpServer();
 
   static void initHttpsServer(bool _checkCerts);
+
+  /**
+   * @brief Initializes `taskArena` field
+   */
+  static void initThreadPool(size_t _numThreads);
 
   static int exitServer();
 

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -29,8 +29,8 @@
 
 #include <functional>
 #include <jsonrpccpp/server/connectors/httpserver.h>
-#include <tbb/task_arena.h>
 #include <tbb/global_control.h>
+#include <tbb/task_arena.h>
 
 #include "abstractstubserver.h"
 
@@ -79,8 +79,8 @@ class SGXWalletServer : public AbstractStubServer {
                                 const string &_key, const string &_value);
 
 public:
-  /// Defines number of threads to be used by SGX on each call (for the ones with 
-  /// thread pool support)
+  /// Defines number of threads to be used by SGX on each call (for the ones
+  /// with thread pool support)
   static const size_t DEFAULT_NUM_THREADS_SGX = 32;
 
   static bool verifyCert(string &_certFileName);

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -29,6 +29,7 @@
 
 #include <jsonrpccpp/server/connectors/httpserver.h>
 #include <tbb/task_arena.h>
+#include <functional>
 
 #include "abstractstubserver.h"
 
@@ -72,11 +73,12 @@ class SGXWalletServer : public AbstractStubServer {
   // Must be initialized before any calls to the server
   static thread_pool threadPool;
   
-
   static void checkForDuplicate(map<string, string> &_map, recursive_mutex &_m,
                                 const string &_key, const string &_value);
 
 public:
+  static const size_t DEFAULT_NUM_THREADS_SGX = 16;
+
   static bool verifyCert(string &_certFileName);
 
   static const char *getVersion() { return TOSTRING(SGXWALLET_VERSION); }

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -27,9 +27,9 @@
 #include "memory"
 #include "mutex"
 
+#include <functional>
 #include <jsonrpccpp/server/connectors/httpserver.h>
 #include <tbb/task_arena.h>
-#include <functional>
 
 #include "abstractstubserver.h"
 
@@ -51,9 +51,7 @@ class SGXWalletServer : public AbstractStubServer {
     }
 
     // delegate task execution to TBB task arena
-    void execute(function<void()> task) {
-      arena.execute(task);
-    }
+    void execute(function<void()> task) { arena.execute(task); }
 
   private:
     tbb::task_arena arena;
@@ -72,7 +70,7 @@ class SGXWalletServer : public AbstractStubServer {
   // to be executed in parallel by this thread pool
   // Must be initialized before any calls to the server
   static thread_pool threadPool;
-  
+
   static void checkForDuplicate(map<string, string> &_map, recursive_mutex &_m,
                                 const string &_key, const string &_value);
 

--- a/SGXWalletServer.hpp
+++ b/SGXWalletServer.hpp
@@ -33,6 +33,7 @@
 #include <tbb/task_arena.h>
 
 #include "abstractstubserver.h"
+#include "common.h"
 
 using namespace jsonrpc;
 using namespace std;
@@ -49,15 +50,23 @@ class SGXWalletServer : public AbstractStubServer {
   struct thread_pool {
     size_t size;
 
-    void initialize(size_t _size) {
-      size = _size;
-      arena.initialize(_size);
+    void initialize(size_t _size = DEFAULT_NUM_THREADS_SGX) {
+      CHECK_STATE(_size > 0);
+
+      if (!initialized) {
+        arena.initialize(_size);
+        size = _size;
+        initialized = true;
+      }
     }
+
+    bool isInitialized() const { return initialized; }
 
     // delegate task execution to TBB task arena
     void execute(function<void()> task) { arena.execute(task); }
 
   private:
+    bool initialized = false;
     tbb::task_arena arena;
   };
 

--- a/ServerInit.cpp
+++ b/ServerInit.cpp
@@ -163,12 +163,11 @@ uint64_t initEnclave() {
   return SGX_SUCCESS;
 }
 
-void initAll(uint32_t _logLevel, bool _checkCert, bool _checkZMQSig,
-             bool _autoSign, bool _generateTestKeys, bool _checkKeyOwnership) {
+void initAll(initConfig& _config) {
 
   static atomic<bool> sgxServerInited(false);
   static mutex initMutex;
-  enclaveLogLevel = _logLevel;
+  enclaveLogLevel = _config.logLevel;
 
   lock_guard<mutex> lock(initMutex);
 
@@ -199,12 +198,12 @@ void initAll(uint32_t _logLevel, bool _checkCert, bool _checkZMQSig,
     initSEK();
 
     SGXWalletServer::createCertsIfNeeded();
-    SGXWalletServer::initThreadPool(SGXWalletServer::DEFAULT_NUM_THREADS_SGX);
+    SGXWalletServer::initThreadPool(_config.threadPoolSize);
 
     if (useHTTPS) {
       spdlog::info("Initing JSON-RPC server over HTTPS");
-      spdlog::info("Check client cert: {}", _checkCert);
-      SGXWalletServer::initHttpsServer(_checkCert);
+      spdlog::info("Check client cert: {}", _config.checkCert);
+      SGXWalletServer::initHttpsServer(_config.checkCert);
       spdlog::info("Inited JSON-RPC server over HTTPS");
     } else {
       spdlog::info("Initing JSON-RPC server over HTTP");
@@ -212,11 +211,11 @@ void initAll(uint32_t _logLevel, bool _checkCert, bool _checkZMQSig,
       spdlog::info("Inited JSON-RPC server over HTTP");
     }
 
-    SGXRegistrationServer::initRegistrationServer(_autoSign);
+    SGXRegistrationServer::initRegistrationServer(_config.autoSign);
     CSRManagerServer::initCSRManagerServer();
-    SGXInfoServer::initInfoServer(_logLevel, _checkCert, _autoSign,
-                                  _generateTestKeys);
-    ZMQServer::initZMQServer(_checkZMQSig, _checkKeyOwnership);
+    SGXInfoServer::initInfoServer(_config.logLevel, _config.checkCert, _config.autoSign,
+                                  _config.generateTestKeys);
+    ZMQServer::initZMQServer(_config.checkZMQSig, _config.checkKeyOwnership);
 
     sgxServerInited = true;
   } catch (SGXException &_e) {

--- a/ServerInit.cpp
+++ b/ServerInit.cpp
@@ -62,6 +62,8 @@
 
 uint32_t enclaveLogLevel = 0;
 
+constexpr size_t NUM_THREADS = 16;
+
 using namespace std;
 
 void systemHealthCheck() {
@@ -199,6 +201,7 @@ void initAll(uint32_t _logLevel, bool _checkCert, bool _checkZMQSig,
     initSEK();
 
     SGXWalletServer::createCertsIfNeeded();
+    SGXWalletServer::initThreadPool(NUM_THREADS);
 
     if (useHTTPS) {
       spdlog::info("Initing JSON-RPC server over HTTPS");

--- a/ServerInit.cpp
+++ b/ServerInit.cpp
@@ -163,7 +163,7 @@ uint64_t initEnclave() {
   return SGX_SUCCESS;
 }
 
-void initAll(initConfig& _config) {
+void initAll(initConfig &_config) {
 
   static atomic<bool> sgxServerInited(false);
   static mutex initMutex;
@@ -213,8 +213,8 @@ void initAll(initConfig& _config) {
 
     SGXRegistrationServer::initRegistrationServer(_config.autoSign);
     CSRManagerServer::initCSRManagerServer();
-    SGXInfoServer::initInfoServer(_config.logLevel, _config.checkCert, _config.autoSign,
-                                  _config.generateTestKeys);
+    SGXInfoServer::initInfoServer(_config.logLevel, _config.checkCert,
+                                  _config.autoSign, _config.generateTestKeys);
     ZMQServer::initZMQServer(_config.checkZMQSig, _config.checkKeyOwnership);
 
     sgxServerInited = true;

--- a/ServerInit.cpp
+++ b/ServerInit.cpp
@@ -62,8 +62,6 @@
 
 uint32_t enclaveLogLevel = 0;
 
-constexpr size_t NUM_THREADS = 16;
-
 using namespace std;
 
 void systemHealthCheck() {
@@ -201,7 +199,7 @@ void initAll(uint32_t _logLevel, bool _checkCert, bool _checkZMQSig,
     initSEK();
 
     SGXWalletServer::createCertsIfNeeded();
-    SGXWalletServer::initThreadPool(NUM_THREADS);
+    SGXWalletServer::initThreadPool(SGXWalletServer::DEFAULT_NUM_THREADS_SGX);
 
     if (useHTTPS) {
       spdlog::info("Initing JSON-RPC server over HTTPS");

--- a/ServerInit.h
+++ b/ServerInit.h
@@ -32,9 +32,17 @@
 #define EXTERNC
 #endif
 
-EXTERNC void initAll(uint32_t _logLevel, bool _checkCert, bool _checkZMQSig,
-                     bool _autoSign, bool _generateTestKeys,
-                     bool _checkKeyOwnership);
+struct initConfig {
+    uint32_t logLevel;
+    bool checkCert;
+    bool checkZMQSig;
+    bool autoSign;
+    bool generateTestKeys;
+    bool checkKeyOwnership;
+    int threadPoolSize;
+};
+
+EXTERNC void initAll(initConfig& config);
 
 void exitAll();
 

--- a/ServerInit.h
+++ b/ServerInit.h
@@ -33,16 +33,16 @@
 #endif
 
 struct initConfig {
-    uint32_t logLevel;
-    bool checkCert;
-    bool checkZMQSig;
-    bool autoSign;
-    bool generateTestKeys;
-    bool checkKeyOwnership;
-    int threadPoolSize;
+  uint32_t logLevel;
+  bool checkCert;
+  bool checkZMQSig;
+  bool autoSign;
+  bool generateTestKeys;
+  bool checkKeyOwnership;
+  int threadPoolSize;
 };
 
-EXTERNC void initAll(initConfig& config);
+EXTERNC void initAll(initConfig &config);
 
 void exitAll();
 

--- a/TECrypto.cpp
+++ b/TECrypto.cpp
@@ -89,6 +89,14 @@ calculateDecryptionShares(const string &encryptedKeyShare,
   // decypher each batch size at a time
   while (numBatchesRemaining > 0) {
 
+    CHECK_STATE(&errStatus);
+    CHECK_STATE(errMsg.data());
+    CHECK_STATE(encryptedKey);
+    CHECK_STATE(currentBatch);
+    CHECK_STATE(decryptionShares);
+    CHECK_STATE(decryptionSharesStatus);
+    CHECK_STATE(currentBatchLength <= BATCH_SIZE_BYTES);
+
     status = trustedGetDecryptionShares(
         eid, &errStatus, errMsg.data(), encryptedKey, currentBatch,
         currentBatchLength, sz, decryptionShares, decryptionSharesStatus);

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -3,16 +3,10 @@
 1. Create virtual environment & install all dependencies:
 
 ```bash
+apt install -y swig
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-```
-
-2. Copy the certificates from remote machine into current folder:
-```bash
-IP=<yout-ip> ;
-scp root@$IP:/root/sgxwallet/sgx_data/cert_data/SGXServerCert.crt ./sgx.crt ;
-scp root@$IP:/root/sgxwallet/sgx_data/cert_data/SGXServerCert.key ./sgx.key
 ```
 
 2. Run the test

--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -14,3 +14,11 @@ pip install -r requirements.txt
 python3 decryptShares.py --ip $IP
 
 ```
+
+3. Analyze the plots
+
+The plots are generated under `plots` directory.
+They are composed of:
+1) Strong blue line -> This is the mean of all requests sent for each point
+2) Light blue area -> Is the standard deviation area. The larger the area the more inconsistent the times are.
+3) Red areas on top & bottom of light blue area -> Represent the RTT (round trip time) standard deviation area. This is useful when measuring performance over network to see how much the RTT influences the times.

--- a/performance-tests/getDecryptedShares.py
+++ b/performance-tests/getDecryptedShares.py
@@ -28,12 +28,12 @@ class DecryptSharesTest(PerformanceTest):
         ]
 
         # single thread data
-        self.batch_sizes = [50, 100, 200, 400, 800, 1600]
-        self.num_batches_each = 2
+        self.batch_sizes = [1600]
+        self.num_batches_each = 5
 
         # parallel test data
-        self.parallel_threads = [ 1, 2, 4, 8]
-        self.parallel_batch_size = 1000
+        self.parallel_threads = [ 1, 2, 4, 8, 16 ]
+        self.parallel_batch_size = 1600
     
     # Send by default batch of size 1000 - for parallel tests
     def create_payload(self, var: int = 1000, **kwargs) -> Dict[str, Any]:
@@ -51,8 +51,8 @@ class DecryptSharesTest(PerformanceTest):
 
 async def main(args):
     test = await DecryptSharesTest.create(args.ip)
-    # results = await test.run_serial_test(test.batch_sizes, test.num_batches_each)
-    # test.plot_results(results, "Batch size", "Time (ms)", "DecryptShares Performance Test", "getDecryptionShares-single-thread")
+    results = await test.run_serial_test(test.batch_sizes, test.num_batches_each)
+    test.plot_results(results, "Batch size", "Time (ms)", "DecryptShares Performance Test", "getDecryptionShares-single-thread")
 
     resutls = await test.run_parallel_test(test.parallel_threads, test.parallel_batch_size)
     test.plot_results(resutls, "Number of Threads", "Trhoughput", "DecryptShares Performance Test", "getDecryptionShares-parallel")

--- a/performance-tests/getDecryptedShares.py
+++ b/performance-tests/getDecryptedShares.py
@@ -27,10 +27,10 @@ class DecryptSharesTest(PerformanceTest):
             "1167e1f5c133ec7f90856379036269cfbb4301088e845be781c9fca33d7147ce07e2568d1dd7d91792c57b81a5180f734148885651fc9bfba6d8e462ca46f6e306b773010b64df82f927d75780ba8a660ad450fd0a6a5cee3e0d0d7862b2b4d51a90e322711fefbf690fa062e983f301f02a82a1274d067c1c0d853444519ff7",
         ]
 
-        self.num_batches_each = 30
+        self.num_batches_each = 50
 
         # single request data
-        self.batch_sizes = [100, 200, 500, 1000, 2000]
+        self.batch_sizes = [2, 4, 8, 16, 32, 64, 128]
 
         # parallel test data
         self.parallel_threads = [ 1, 2, 4, 8, 16]

--- a/performance-tests/getDecryptedShares.py
+++ b/performance-tests/getDecryptedShares.py
@@ -27,13 +27,14 @@ class DecryptSharesTest(PerformanceTest):
             "1167e1f5c133ec7f90856379036269cfbb4301088e845be781c9fca33d7147ce07e2568d1dd7d91792c57b81a5180f734148885651fc9bfba6d8e462ca46f6e306b773010b64df82f927d75780ba8a660ad450fd0a6a5cee3e0d0d7862b2b4d51a90e322711fefbf690fa062e983f301f02a82a1274d067c1c0d853444519ff7",
         ]
 
-        # single thread data
-        self.batch_sizes = [1600]
-        self.num_batches_each = 5
+        self.num_batches_each = 30
+
+        # single request data
+        self.batch_sizes = [100, 200, 500, 1000, 2000]
 
         # parallel test data
-        self.parallel_threads = [ 1, 2, 4, 8, 16 ]
-        self.parallel_batch_size = 1600
+        self.parallel_threads = [ 1, 2, 4, 8, 16]
+        self.parallel_batch_size = 2000
     
     # Send by default batch of size 1000 - for parallel tests
     def create_payload(self, var: int = 1000, **kwargs) -> Dict[str, Any]:
@@ -54,8 +55,8 @@ async def main(args):
     results = await test.run_serial_test(test.batch_sizes, test.num_batches_each)
     test.plot_results(results, "Batch size", "Time (ms)", "DecryptShares Performance Test", "getDecryptionShares-single-thread")
 
-    resutls = await test.run_parallel_test(test.parallel_threads, test.parallel_batch_size)
-    test.plot_results(resutls, "Number of Threads", "Trhoughput", "DecryptShares Performance Test", "getDecryptionShares-parallel")
+    # resutls = await test.run_parallel_test(test.parallel_threads, test.parallel_batch_size, test.num_batches_each)
+    # test.plot_results(resutls, "Number of Threads", "Trhoughput", "DecryptShares Performance Test", "getDecryptionShares-parallel")
 
 
 

--- a/performance-tests/utils/performance_test.py
+++ b/performance-tests/utils/performance_test.py
@@ -1,11 +1,68 @@
 import time
 import asyncio
+import numpy as np
 import aiohttp
 import matplotlib.pyplot as plt
 from abc import ABC, abstractmethod
 from typing import Dict, List, Any, Optional
 from utils.sgx_key_utils import provision_keys
 
+
+class Results:
+    def __init__(self, rtt: int, rtt_std: int, mean_times: Dict[int, tuple[int, float]], 
+                 std: Dict[int, float]):
+        # get times only
+        mean_times_updated = {k: v[1] for k, v in mean_times.items()}
+        # get batch size only
+        num_reqsts_sent = np.array([x[0] for x in mean_times.values()])
+        self.x_vals = np.array(list(mean_times_updated.keys()))
+        times_list = np.array(list(mean_times_updated.values()))
+
+        print(times_list)
+        print(num_reqsts_sent)
+        print(rtt, rtt_std)
+
+        times_without_rtt = times_list - rtt
+        print(f"{'times without RTT':<30} {times_without_rtt}")
+        # 1000 -> convert from ms to seconds        
+        self.y_vals = num_reqsts_sent / (times_without_rtt / 1000)
+        print(f"{'throughput mean:':<30} {self.y_vals}")
+
+        y_std = np.array(list(std.values()))
+        print(f"{'std:':<30} {y_std}")
+
+        self.upper_bound = np.maximum(num_reqsts_sent / ((times_without_rtt + y_std) / 1000), 0)
+        self.lower_bound = np.maximum(num_reqsts_sent / ((times_without_rtt - y_std) / 1000), 0)
+        print(f"{'upper bound:':<30} {self.upper_bound}")
+        print(f"{'lower bound:':<30} {self.lower_bound}")
+
+        self.rtt_upper_bound_upper_std = np.maximum(num_reqsts_sent / ((times_without_rtt + y_std + rtt_std) / 1000), 0)
+        self.rtt_upper_bound_lower_std = np.maximum(num_reqsts_sent / ((times_without_rtt + y_std - rtt_std) / 1000), 0)
+        print(f"{'RTT upper bound upper std:':<30} {self.rtt_upper_bound_upper_std}")
+        print(f"{'RTT upper bound lower std:':<30} {self.rtt_upper_bound_lower_std}")
+
+        self.rtt_lower_bound_upper_std = np.maximum(num_reqsts_sent / ((times_without_rtt - y_std + rtt_std) / 1000), 0)
+        self.rtt_lower_bound_lower_std = np.maximum(num_reqsts_sent / ((times_without_rtt - y_std - rtt_std) / 1000), 0)
+        print(f"{'RTT lower bound upper std:':<30} {self.rtt_lower_bound_upper_std}")
+        print(f"{'RTT lower bound lower std:':<30} {self.rtt_lower_bound_lower_std}")
+
+    def plot(self, title: str, xlabel: str, ylabel: str, filename: str):
+        plt.figure(figsize=(10, 6))
+        # plot the main line
+        plt.plot(self.x_vals, self.y_vals, marker='o')
+        # plot the standard deviation area
+        plt.fill_between(self.x_vals, self.upper_bound, self.lower_bound, color='blue', alpha=0.25, label='±1 Std Dev')
+        # plot RTT bounds on the upper side of the area of the above area
+        plt.fill_between(self.x_vals, self.rtt_upper_bound_upper_std, self.rtt_upper_bound_lower_std, color='red', alpha=0.5, label='RTT ± Std Dev')
+        # plot RTT bounds on the lower side of the area of the above area
+        plt.fill_between(self.x_vals, self.rtt_lower_bound_upper_std, self.rtt_lower_bound_lower_std, color='red', alpha=0.5, label='RTT ± Std Dev')
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+        plt.title(title)
+        plt.grid(True)
+        plt.savefig(f"./plots/{filename}.png")
+        plt.show()
+    
 
 class PerformanceTest(ABC):
     """Base class for performance tests"""
@@ -16,6 +73,7 @@ class PerformanceTest(ABC):
         # Initialized on 'create' method
         self.keys = None
         self.rtt = None
+        self.rtt_std = None
 
     @classmethod
     async def create(cls, ip: str):
@@ -27,12 +85,12 @@ class PerformanceTest(ABC):
     async def initialize(self):
         """Initialize async components like RTT measurement"""
         if self.rtt is None:
-            self.rtt = await self._measure_rtt()
+            (self.rtt, self.rtt_std) = await self._measure_rtt()
 
         print("Generating keys...")
         self.keys = provision_keys(self.endpoint)
     
-    async def _measure_rtt(self, num_samples: int = 10) -> float:
+    async def _measure_rtt(self, num_samples: int = 50) -> tuple[float, float]:
         """Measure round-trip time with invalid requests"""
         print("Measuring RTT...")
         
@@ -44,9 +102,10 @@ class PerformanceTest(ABC):
                 _, elapsed = await self.make_single_request(session, False)
                 times.append(elapsed)
         
-        avg_rtt = sum(times) / len(times)
+        avg_rtt = np.mean(times)
+        std_rtt = np.std(times)
         print(f"Average RTT: {avg_rtt:.2f} ms")
-        return avg_rtt
+        return (avg_rtt, std_rtt)
     
     @abstractmethod
     def create_payload(self, **kwargs) -> Dict[str, Any]:
@@ -81,60 +140,57 @@ class PerformanceTest(ABC):
             
         return result, (end - start) * 1000 # Convert to ms
     
-    async def run_parallel_test(self, num_threads: List[int], variable: int, **kwargs) -> Dict[int, float]:
+    # Returns a tuple ( results, standard deviation )
+    async def run_parallel_test(self, num_threads: List[int], variable: int, num_iterations: int = 2, **kwargs) -> Results:
         """Run parallel throughput test with different thread counts"""
         print("Running parallel throughput test...")
         results = {}
+        standard_devs = {}
         
         connector = aiohttp.TCPConnector(ssl=None)
         async with aiohttp.ClientSession(connector=connector) as session:
             
             for threads in num_threads:
-                start_time = time.perf_counter()
+                times = []
+                for _ in range(num_iterations):
+                    start_time = time.perf_counter()
+                    # Create N parallel tasks
+                    tasks = [self.make_single_request(session, True, var = variable, **kwargs) for _ in range(threads)]
+                    await asyncio.gather(*tasks)
+                    total_time = (time.perf_counter() - start_time)
+                    times.append(total_time)
                 
-                # Create N parallel tasks
-                tasks = [self.make_single_request(session, True, var = variable, **kwargs) for _ in range(threads)]
-                await asyncio.gather(*tasks)
+                results[threads] = (variable, np.mean(times))
+                standard_devs[threads] = np.std(times)
                 
-                total_time = (time.perf_counter() - start_time) * 1000 - self.rtt
-                throughput = (threads * variable) / (total_time / 1000)  # requests per second
-                
-                results[threads] = throughput
-                print(f"{threads:2d} threads: {total_time:8.2f} ms total, {throughput:6.2f} req/s")
+                print(f"{threads:2d} threads: {np.mean(times):8.2f} ms total, +-{np.std(times):6.2f} ms")
         
-        return results
+        return Results(self.rtt, self.rtt_std, results, standard_devs, variable)
     
-    async def run_serial_test(self, variable: List[int], num_iterations: int = 2, **kwargs) -> Dict[int, float]:
+    # Returns a tuple ( results, standard deviation )
+    async def run_serial_test(self, variable: List[int], num_iterations: int = 2, **kwargs) -> Results:
         """Run single-threaded batch size test"""
         print("Running single-threaded variable test...")
         results = {}
+        standard_devs = {}
         
         connector = aiohttp.TCPConnector(ssl=None)
         async with aiohttp.ClientSession(connector=connector) as session:
             
             for var in variable:
-                total_time = 0
-                
+                times = []
+
                 for _ in range(num_iterations):
                     _, elapsed = await self.make_single_request(session, True, var=var, **kwargs)
-                    total_time += elapsed - self.rtt # Subtract RTT overhead
+                    times.append(elapsed)
                 
-                avg_time = total_time / num_iterations
-                results[var] = avg_time
-                print(f"Variable value: {var:4d} | Mean Time: {avg_time:8.2f} ms")
+                results[var] = (var, np.mean(times))
+                standard_devs[var] = np.std(times)
+                print(f"Variable value: {var:4d} | Mean Time: {np.mean(times):8.2f} ms")
         
-        return results
+        return Results(self.rtt, self.rtt_std, results, standard_devs)
     
-    def plot_results(self, data: Dict[int, float], xlabel: str, ylabel: str, title: str, filename: str):
+
+    def plot_results(self, data: Results, xlabel: str, ylabel: str, title: str, filename: str):
         """Plot and save results"""
-        x_vals = list(data.keys())
-        y_vals = list(data.values())
-        
-        plt.figure(figsize=(10, 6))
-        plt.plot(x_vals, y_vals, marker='o')
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
-        plt.title(title)
-        plt.grid(True)
-        plt.savefig(f"./plots/{filename}.png")
-        plt.show()
+        data.plot(title, xlabel, ylabel, filename)

--- a/performance-tests/utils/performance_test.py
+++ b/performance-tests/utils/performance_test.py
@@ -1,7 +1,6 @@
 import time
 import asyncio
 import aiohttp
-import ssl
 import matplotlib.pyplot as plt
 from abc import ABC, abstractmethod
 from typing import Dict, List, Any, Optional
@@ -12,11 +11,9 @@ class PerformanceTest(ABC):
     """Base class for performance tests"""
     
     def __init__(self, ip: str):
-        self.endpoint = "https://" + ip + ":1026"
-        self.cert_path = "."
+        self.endpoint = "http://" + ip + ":1029"
 
         # Initialized on 'create' method
-        self.ssl_context = None
         self.keys = None
         self.rtt = None
 
@@ -29,27 +26,17 @@ class PerformanceTest(ABC):
     
     async def initialize(self):
         """Initialize async components like RTT measurement"""
-        self.ssl_context = self._create_ssl_context()
-
         if self.rtt is None:
             self.rtt = await self._measure_rtt()
 
         print("Generating keys...")
-        self.keys = provision_keys(self.endpoint, self.cert_path)
-    
-    def _create_ssl_context(self):
-        """Create SSL context with client certificates"""
-        ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        ssl_context.load_cert_chain(f"{self.cert_path}/sgx.crt", f"{self.cert_path}/sgx.key")
-        return ssl_context
+        self.keys = provision_keys(self.endpoint)
     
     async def _measure_rtt(self, num_samples: int = 10) -> float:
         """Measure round-trip time with invalid requests"""
         print("Measuring RTT...")
         
-        connector = aiohttp.TCPConnector(ssl=self.ssl_context)  
+        connector = aiohttp.TCPConnector(ssl=None)  
         async with aiohttp.ClientSession(connector = connector) as session:
             times = []
             for _ in range(num_samples):
@@ -99,7 +86,7 @@ class PerformanceTest(ABC):
         print("Running parallel throughput test...")
         results = {}
         
-        connector = aiohttp.TCPConnector(ssl=self.ssl_context)
+        connector = aiohttp.TCPConnector(ssl=None)
         async with aiohttp.ClientSession(connector=connector) as session:
             
             for threads in num_threads:
@@ -122,7 +109,7 @@ class PerformanceTest(ABC):
         print("Running single-threaded variable test...")
         results = {}
         
-        connector = aiohttp.TCPConnector(ssl=self.ssl_context)
+        connector = aiohttp.TCPConnector(ssl=None)
         async with aiohttp.ClientSession(connector=connector) as session:
             
             for var in variable:

--- a/performance-tests/utils/performance_test.py
+++ b/performance-tests/utils/performance_test.py
@@ -18,33 +18,33 @@ class Results:
         self.x_vals = np.array(list(mean_times_updated.keys()))
         times_list = np.array(list(mean_times_updated.values()))
 
-        print(times_list)
-        print(num_reqsts_sent)
-        print(rtt, rtt_std)
+        # print(times_list)
+        # print(num_reqsts_sent)
+        # print(rtt, rtt_std)
 
         times_without_rtt = times_list - rtt
-        print(f"{'times without RTT':<30} {times_without_rtt}")
+        # print(f"{'times without RTT':<30} {times_without_rtt}")
         # 1000 -> convert from ms to seconds        
         self.y_vals = num_reqsts_sent / (times_without_rtt / 1000)
-        print(f"{'throughput mean:':<30} {self.y_vals}")
+        # print(f"{'throughput mean:':<30} {self.y_vals}")
 
         y_std = np.array(list(std.values()))
-        print(f"{'std:':<30} {y_std}")
+        # print(f"{'std:':<30} {y_std}")
 
         self.upper_bound = np.maximum(num_reqsts_sent / ((times_without_rtt + y_std) / 1000), 0)
         self.lower_bound = np.maximum(num_reqsts_sent / ((times_without_rtt - y_std) / 1000), 0)
-        print(f"{'upper bound:':<30} {self.upper_bound}")
-        print(f"{'lower bound:':<30} {self.lower_bound}")
+        # print(f"{'upper bound:':<30} {self.upper_bound}")
+        # print(f"{'lower bound:':<30} {self.lower_bound}")
 
         self.rtt_upper_bound_upper_std = np.maximum(num_reqsts_sent / ((times_without_rtt + y_std + rtt_std) / 1000), 0)
         self.rtt_upper_bound_lower_std = np.maximum(num_reqsts_sent / ((times_without_rtt + y_std - rtt_std) / 1000), 0)
-        print(f"{'RTT upper bound upper std:':<30} {self.rtt_upper_bound_upper_std}")
-        print(f"{'RTT upper bound lower std:':<30} {self.rtt_upper_bound_lower_std}")
+        # print(f"{'RTT upper bound upper std:':<30} {self.rtt_upper_bound_upper_std}")
+        # print(f"{'RTT upper bound lower std:':<30} {self.rtt_upper_bound_lower_std}")
 
         self.rtt_lower_bound_upper_std = np.maximum(num_reqsts_sent / ((times_without_rtt - y_std + rtt_std) / 1000), 0)
         self.rtt_lower_bound_lower_std = np.maximum(num_reqsts_sent / ((times_without_rtt - y_std - rtt_std) / 1000), 0)
-        print(f"{'RTT lower bound upper std:':<30} {self.rtt_lower_bound_upper_std}")
-        print(f"{'RTT lower bound lower std:':<30} {self.rtt_lower_bound_lower_std}")
+        # print(f"{'RTT lower bound upper std:':<30} {self.rtt_lower_bound_upper_std}")
+        # print(f"{'RTT lower bound lower std:':<30} {self.rtt_lower_bound_lower_std}")
 
     def plot(self, title: str, xlabel: str, ylabel: str, filename: str):
         plt.figure(figsize=(10, 6))

--- a/performance-tests/utils/sgx_key_utils.py
+++ b/performance-tests/utils/sgx_key_utils.py
@@ -4,8 +4,8 @@ import os
 import json
 from sgx import SgxClient
 
-def provision_keys(sgx_url: str, cert_path: str, dkg_id: int = None) -> dict:
-    sgx = SgxClient(sgx_url, path_to_cert=cert_path)
+def provision_keys(sgx_url: str, dkg_id: int = None) -> dict:
+    sgx = SgxClient(sgx_url)
 
     if dkg_id is None:
         dkg_id = random.randint(0, 10**50)

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -3,8 +3,8 @@
 # This script is also used by docker files to install
 # the required packages for building the project.
 
-sudo apt update
-sudo apt install -y build-essential \
+apt update
+apt install -y build-essential \
     ocaml \
     ocamlbuild \
     automake \

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# This script is also used by docker files to install
+# the required packages for building the project.
+
 sudo apt update
 sudo apt install -y build-essential \
     ocaml \

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -22,5 +22,6 @@ sudo apt install -y build-essential \
     libboost-dev \
     libboost-system-dev \
     libboost-thread-dev \
+    libtbb-dev \
     lsb-release \
     libsystemd0

--- a/secure_enclave/secure_enclave.c
+++ b/secure_enclave/secure_enclave.c
@@ -1390,8 +1390,9 @@ void trustedGetDecryptionShares( int *errStatus, char* errString, uint8_t* encry
 
     INIT_ERROR_STATE
 
-    CHECK_STATE(decryption_shares);
     CHECK_STATE(encryptedPrivateKey);
+    CHECK_STATE(public_decryption_value);
+    CHECK_STATE(decryption_shares);
     CHECK_STATE(decryption_shares_status);
 
     SAFE_CHAR_BUF(skey_hex, BUF_LEN);

--- a/secure_enclave/secure_enclave.config.xml
+++ b/secure_enclave/secure_enclave.config.xml
@@ -3,9 +3,9 @@
  <ISVSVN>4</ISVSVN>
  <StackMaxSize>0x1000000</StackMaxSize>
  <HeapMaxSize>0x10000000</HeapMaxSize>
- <TCSNum>64</TCSNum>
+ <TCSNum>128</TCSNum>
  <TCSMaxNum>256</TCSMaxNum>
- <TCSMinPool>64</TCSMinPool>
+ <TCSMinPool>128</TCSMinPool>
  <TCSPolicy>0</TCSPolicy>
  <!-- Recommend changing 'DisableDebug' to 1 to make the enclave undebuggable for enclave release -->
  <DisableDebug>0</DisableDebug>

--- a/secure_enclave/secure_enclave.config.xml
+++ b/secure_enclave/secure_enclave.config.xml
@@ -11,5 +11,4 @@
  <DisableDebug>0</DisableDebug>
  <MiscSelect>0</MiscSelect>
  <MiscMask>0xFFFFFFFF</MiscMask>
- <XFRM>0x07</XFRM>
  </EnclaveConfiguration>

--- a/secure_enclave/secure_enclave.config.xml
+++ b/secure_enclave/secure_enclave.config.xml
@@ -3,9 +3,9 @@
  <ISVSVN>4</ISVSVN>
  <StackMaxSize>0x1000000</StackMaxSize>
  <HeapMaxSize>0x10000000</HeapMaxSize>
- <TCSNum>128</TCSNum>
+ <TCSNum>64</TCSNum>
  <TCSMaxNum>256</TCSMaxNum>
- <TCSMinPool>128</TCSMinPool>
+ <TCSMinPool>64</TCSMinPool>
  <TCSPolicy>0</TCSPolicy>
  <!-- Recommend changing 'DisableDebug' to 1 to make the enclave undebuggable for enclave release -->
  <DisableDebug>0</DisableDebug>

--- a/secure_enclave/secure_enclave.config.xml
+++ b/secure_enclave/secure_enclave.config.xml
@@ -3,12 +3,13 @@
  <ISVSVN>4</ISVSVN>
  <StackMaxSize>0x1000000</StackMaxSize>
  <HeapMaxSize>0x10000000</HeapMaxSize>
- <TCSNum>256</TCSNum>
+ <TCSNum>64</TCSNum>
  <TCSMaxNum>256</TCSMaxNum>
- <TCSMinPool>256</TCSMinPool>
+ <TCSMinPool>64</TCSMinPool>
  <TCSPolicy>0</TCSPolicy>
  <!-- Recommend changing 'DisableDebug' to 1 to make the enclave undebuggable for enclave release -->
  <DisableDebug>0</DisableDebug>
  <MiscSelect>0</MiscSelect>
  <MiscMask>0xFFFFFFFF</MiscMask>
+ <XFRM>0x07</XFRM>
  </EnclaveConfiguration>

--- a/secure_enclave/secure_enclave.config.xml.release
+++ b/secure_enclave/secure_enclave.config.xml.release
@@ -3,9 +3,9 @@
  <ISVSVN>4</ISVSVN>
  <StackMaxSize>0x1000000</StackMaxSize>
  <HeapMaxSize>0x10000000</HeapMaxSize>
- <TCSNum>256</TCSNum>
+ <TCSNum>64</TCSNum>
  <TCSMaxNum>256</TCSMaxNum>
- <TCSMinPool>256</TCSMinPool>
+ <TCSMinPool>64</TCSMinPool>
  <TCSPolicy>0</TCSPolicy>
  <!-- Recommend changing 'DisableDebug' to 1 to make the enclave undebuggable for enclave release -->
  <DisableDebug>1</DisableDebug>

--- a/secure_enclave/secure_enclave.config.xml.sim
+++ b/secure_enclave/secure_enclave.config.xml.sim
@@ -3,9 +3,9 @@
  <ISVSVN>4</ISVSVN>
  <StackMaxSize>0x200000</StackMaxSize>
  <HeapMaxSize>0x200000</HeapMaxSize>
- <TCSNum>25</TCSNum>
- <TCSMaxNum>25</TCSMaxNum>
- <TCSMinPool>25</TCSMinPool>
+ <TCSNum>64</TCSNum>
+ <TCSMaxNum>256</TCSMaxNum>
+ <TCSMinPool>64</TCSMinPool>
  <TCSPolicy>0</TCSPolicy>
  <!-- Recommend changing 'DisableDebug' to 1 to make the enclave undebuggable for enclave release -->
  <DisableDebug>0</DisableDebug>

--- a/sgxwall.cpp
+++ b/sgxwall.cpp
@@ -31,6 +31,7 @@
 
 #include "SEKManager.h"
 #include "SGXWalletServer.h"
+#include "SGXWalletServer.hpp"
 
 #include <fstream>
 
@@ -59,6 +60,9 @@ void SGXWallet::printUsage() {
   cerr << "   -s  Sign client certificates without human confirmation. "
           "Insecure! \n";
   cerr << "   -e  Only owner of the key can access it.\n";
+  cerr << "\nConfiguration flags:\n\n";
+  cerr << "   -t  Set thread pool size. Default is " << SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+       << ". Must be > 0 and < " << SGXWalletServer::DEFAULT_NUM_THREADS_SGX << ".\n";
 }
 
 void SGXWallet::serializeKeys(const vector<string> &_ecdsaKeyNames,
@@ -105,6 +109,7 @@ int main(int argc, char *argv[]) {
   bool autoSignClientCertOption = false;
   bool generateTestKeys = false;
   bool checkKeyOwnership = false;
+  int threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX;
 
   std::signal(SIGABRT, SGXWallet::signalHandler);
 
@@ -115,7 +120,7 @@ int main(int argc, char *argv[]) {
     exit(-21);
   }
 
-  while ((opt = getopt(argc, argv, "cshd0abyvVneT")) != -1) {
+  while ((opt = getopt(argc, argv, "cshd0abyvVneTt:")) != -1) {
     switch (opt) {
     case 'h':
       SGXWallet::printUsage();
@@ -158,6 +163,24 @@ int main(int argc, char *argv[]) {
     case 'T':
       generateTestKeys = true;
       break;
+    case 't': {
+      try {
+        threadPoolSize = std::stoi(optarg); // Convert argument to integer
+        if (threadPoolSize <= 0) {
+          throw std::invalid_argument("Thread pool size must be positive");
+        }
+        else if (threadPoolSize > SGXWalletServer::DEFAULT_NUM_THREADS_SGX) {
+          throw std::invalid_argument(
+              "Thread pool size must not exceed " +
+              std::to_string(SGXWalletServer::DEFAULT_NUM_THREADS_SGX));
+        }
+      } catch (const std::exception &e) {
+        std::cerr << "Invalid thread pool size: " << optarg << "\n";
+        SGXWallet::printUsage();
+        exit(-24);
+      }
+      break;
+    }
     default:
       SGXWallet::printUsage();
       exit(-23);
@@ -189,8 +212,17 @@ int main(int argc, char *argv[]) {
   }
 
   cerr << "Calling initAll ..." << endl;
-  initAll(enclaveLogLevel, checkClientCertOption, checkClientCertOption,
-          autoSignClientCertOption, generateTestKeys, checkKeyOwnership);
+  initConfig initConfig {
+      .logLevel = enclaveLogLevel,
+      .checkCert = checkClientCertOption,
+      .checkZMQSig = checkKeyOwnership,
+      .autoSign = autoSignClientCertOption,
+      .generateTestKeys = generateTestKeys,
+      .checkKeyOwnership = checkKeyOwnership,
+      .threadPoolSize = threadPoolSize
+  };
+
+  initAll(initConfig);
   cerr << "Completed initAll." << endl;
 
   // check if test keys already exist

--- a/sgxwall.cpp
+++ b/sgxwall.cpp
@@ -61,8 +61,9 @@ void SGXWallet::printUsage() {
           "Insecure! \n";
   cerr << "   -e  Only owner of the key can access it.\n";
   cerr << "\nConfiguration flags:\n\n";
-  cerr << "   -t  Set thread pool size. Default is " << SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-       << ". Must be > 0 and < " << SGXWalletServer::DEFAULT_NUM_THREADS_SGX << ".\n";
+  cerr << "   -t  Set thread pool size. Default is "
+       << SGXWalletServer::DEFAULT_NUM_THREADS_SGX << ". Must be > 0 and < "
+       << SGXWalletServer::DEFAULT_NUM_THREADS_SGX << ".\n";
 }
 
 void SGXWallet::serializeKeys(const vector<string> &_ecdsaKeyNames,
@@ -168,8 +169,7 @@ int main(int argc, char *argv[]) {
         threadPoolSize = std::stoi(optarg); // Convert argument to integer
         if (threadPoolSize <= 0) {
           throw std::invalid_argument("Thread pool size must be positive");
-        }
-        else if (threadPoolSize > SGXWalletServer::DEFAULT_NUM_THREADS_SGX) {
+        } else if (threadPoolSize > SGXWalletServer::DEFAULT_NUM_THREADS_SGX) {
           throw std::invalid_argument(
               "Thread pool size must not exceed " +
               std::to_string(SGXWalletServer::DEFAULT_NUM_THREADS_SGX));
@@ -212,15 +212,13 @@ int main(int argc, char *argv[]) {
   }
 
   cerr << "Calling initAll ..." << endl;
-  initConfig initConfig {
-      .logLevel = enclaveLogLevel,
-      .checkCert = checkClientCertOption,
-      .checkZMQSig = checkKeyOwnership,
-      .autoSign = autoSignClientCertOption,
-      .generateTestKeys = generateTestKeys,
-      .checkKeyOwnership = checkKeyOwnership,
-      .threadPoolSize = threadPoolSize
-  };
+  initConfig initConfig{.logLevel = enclaveLogLevel,
+                        .checkCert = checkClientCertOption,
+                        .checkZMQSig = checkKeyOwnership,
+                        .autoSign = autoSignClientCertOption,
+                        .generateTestKeys = generateTestKeys,
+                        .checkKeyOwnership = checkKeyOwnership,
+                        .threadPoolSize = threadPoolSize};
 
   initAll(initConfig);
   cerr << "Completed initAll." << endl;

--- a/testw.cpp
+++ b/testw.cpp
@@ -131,7 +131,18 @@ public:
   TestFixture() {
     TestUtils::resetDB();
     setOptions(L_INFO, false, true);
-    initAll(L_INFO, false, false, true, false, true);
+
+    initConfig config {
+      .logLevel = L_INFO,
+      .checkCert = false,
+      .checkZMQSig = false,
+      .autoSign = true,
+      .generateTestKeys = false,
+      .checkKeyOwnership = true,
+      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+    };
+
+    initAll(config);
   }
 
   ~TestFixture() { TestUtils::destroyEnclave(); }
@@ -142,7 +153,18 @@ public:
   TestFixtureHTTPS() {
     TestUtils::resetDB();
     setOptions(L_INFO, true, true);
-    initAll(L_INFO, true, true, true, false, true);
+
+    initConfig config {
+      .logLevel = L_INFO,
+      .checkCert = true,
+      .checkZMQSig = true,
+      .autoSign = true,
+      .generateTestKeys = false,
+      .checkKeyOwnership = true,
+      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+    };
+
+    initAll(config);
   }
 
   ~TestFixtureHTTPS() { TestUtils::destroyEnclave(); }
@@ -160,7 +182,18 @@ public:
   TestFixtureZMQSign() {
     TestUtils::resetDB();
     setOptions(L_INFO, false, true);
-    initAll(L_INFO, false, true, true, false, false);
+
+    initConfig config {
+      .logLevel = L_INFO,
+      .checkCert = false,
+      .checkZMQSig = true,
+      .autoSign = true,
+      .generateTestKeys = false,
+      .checkKeyOwnership = false,
+      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+    };
+
+    initAll(config);
   }
 
   ~TestFixtureZMQSign() { TestUtils::destroyEnclave(); }
@@ -170,7 +203,18 @@ class TestFixtureNoResetFromBackup {
 public:
   TestFixtureNoResetFromBackup() {
     setFullOptions(L_INFO, false, true, true);
-    initAll(L_INFO, false, false, true, false, true);
+
+    initConfig config {
+      .logLevel = L_INFO,
+      .checkCert = false,
+      .checkZMQSig = false,
+      .autoSign = true,
+      .generateTestKeys = false,
+      .checkKeyOwnership = true,
+      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+    };
+
+    initAll(config);
   }
 
   ~TestFixtureNoResetFromBackup() {
@@ -183,7 +227,18 @@ class TestFixtureNoReset {
 public:
   TestFixtureNoReset() {
     setOptions(L_INFO, false, true);
-    initAll(L_INFO, false, false, true, false, true);
+
+    initConfig config {
+      .logLevel = L_INFO,
+      .checkCert = false,
+      .checkZMQSig = false,
+      .autoSign = true,
+      .generateTestKeys = false,
+      .checkKeyOwnership = true,
+      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+    };
+
+    initAll(config);
   }
 
   ~TestFixtureNoReset() { TestUtils::destroyEnclave(); }
@@ -310,7 +365,18 @@ TEST_CASE_METHOD(TestFixtureHTTPS, "HTTPS certificate not in database",
   // reset db & init enclave again
   TestUtils::resetDB();
   setOptions(L_INFO, true, true);
-  initAll(L_INFO, true, true, true, false, true);
+
+  initConfig config {
+    .logLevel = L_INFO,
+    .checkCert = true,
+    .checkZMQSig = true,
+    .autoSign = true,
+    .generateTestKeys = false,
+    .checkKeyOwnership = true,
+    .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
+  };
+
+  initAll(config);
 
   // make the request
   bool expectedError = true;

--- a/testw.cpp
+++ b/testw.cpp
@@ -132,15 +132,14 @@ public:
     TestUtils::resetDB();
     setOptions(L_INFO, false, true);
 
-    initConfig config {
-      .logLevel = L_INFO,
-      .checkCert = false,
-      .checkZMQSig = false,
-      .autoSign = true,
-      .generateTestKeys = false,
-      .checkKeyOwnership = true,
-      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-    };
+    initConfig config{.logLevel = L_INFO,
+                      .checkCert = false,
+                      .checkZMQSig = false,
+                      .autoSign = true,
+                      .generateTestKeys = false,
+                      .checkKeyOwnership = true,
+                      .threadPoolSize =
+                          SGXWalletServer::DEFAULT_NUM_THREADS_SGX};
 
     initAll(config);
   }
@@ -154,15 +153,14 @@ public:
     TestUtils::resetDB();
     setOptions(L_INFO, true, true);
 
-    initConfig config {
-      .logLevel = L_INFO,
-      .checkCert = true,
-      .checkZMQSig = true,
-      .autoSign = true,
-      .generateTestKeys = false,
-      .checkKeyOwnership = true,
-      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-    };
+    initConfig config{.logLevel = L_INFO,
+                      .checkCert = true,
+                      .checkZMQSig = true,
+                      .autoSign = true,
+                      .generateTestKeys = false,
+                      .checkKeyOwnership = true,
+                      .threadPoolSize =
+                          SGXWalletServer::DEFAULT_NUM_THREADS_SGX};
 
     initAll(config);
   }
@@ -183,15 +181,14 @@ public:
     TestUtils::resetDB();
     setOptions(L_INFO, false, true);
 
-    initConfig config {
-      .logLevel = L_INFO,
-      .checkCert = false,
-      .checkZMQSig = true,
-      .autoSign = true,
-      .generateTestKeys = false,
-      .checkKeyOwnership = false,
-      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-    };
+    initConfig config{.logLevel = L_INFO,
+                      .checkCert = false,
+                      .checkZMQSig = true,
+                      .autoSign = true,
+                      .generateTestKeys = false,
+                      .checkKeyOwnership = false,
+                      .threadPoolSize =
+                          SGXWalletServer::DEFAULT_NUM_THREADS_SGX};
 
     initAll(config);
   }
@@ -204,15 +201,14 @@ public:
   TestFixtureNoResetFromBackup() {
     setFullOptions(L_INFO, false, true, true);
 
-    initConfig config {
-      .logLevel = L_INFO,
-      .checkCert = false,
-      .checkZMQSig = false,
-      .autoSign = true,
-      .generateTestKeys = false,
-      .checkKeyOwnership = true,
-      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-    };
+    initConfig config{.logLevel = L_INFO,
+                      .checkCert = false,
+                      .checkZMQSig = false,
+                      .autoSign = true,
+                      .generateTestKeys = false,
+                      .checkKeyOwnership = true,
+                      .threadPoolSize =
+                          SGXWalletServer::DEFAULT_NUM_THREADS_SGX};
 
     initAll(config);
   }
@@ -228,15 +224,14 @@ public:
   TestFixtureNoReset() {
     setOptions(L_INFO, false, true);
 
-    initConfig config {
-      .logLevel = L_INFO,
-      .checkCert = false,
-      .checkZMQSig = false,
-      .autoSign = true,
-      .generateTestKeys = false,
-      .checkKeyOwnership = true,
-      .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-    };
+    initConfig config{.logLevel = L_INFO,
+                      .checkCert = false,
+                      .checkZMQSig = false,
+                      .autoSign = true,
+                      .generateTestKeys = false,
+                      .checkKeyOwnership = true,
+                      .threadPoolSize =
+                          SGXWalletServer::DEFAULT_NUM_THREADS_SGX};
 
     initAll(config);
   }
@@ -366,15 +361,13 @@ TEST_CASE_METHOD(TestFixtureHTTPS, "HTTPS certificate not in database",
   TestUtils::resetDB();
   setOptions(L_INFO, true, true);
 
-  initConfig config {
-    .logLevel = L_INFO,
-    .checkCert = true,
-    .checkZMQSig = true,
-    .autoSign = true,
-    .generateTestKeys = false,
-    .checkKeyOwnership = true,
-    .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX
-  };
+  initConfig config{.logLevel = L_INFO,
+                    .checkCert = true,
+                    .checkZMQSig = true,
+                    .autoSign = true,
+                    .generateTestKeys = false,
+                    .checkKeyOwnership = true,
+                    .threadPoolSize = SGXWalletServer::DEFAULT_NUM_THREADS_SGX};
 
   initAll(config);
 


### PR DESCRIPTION
# Description

- Added intra-request parallelization for `getDecryptShares`. 
- Now a single request is parallelized over N threads. The following has been parallelized
    - Input parsing & validation - the validation & logic for appending the 256-char strings is now done in parallel. We wait at the end of it to check for any errors from any thread, and only proceed if no errors have been identified,
    - Decryption logic - this is the bulk of the processing time - each thread decrypts a batch of shares in parallel. If we cannot divide evenly, then we add +1 share to the first K threads until there is no more remainder. 
- Added new flag `-t` to specify the number of threads to be used by the threadPool for intra-request parallelization

# Tests

- No changes applied to tests - all logic is the same. Only difference is that it now runs in parallel

# Evaluation

Conducted several tests with several configurations.
**Initial configuration** - 1 thread, 256 TCS, reached ~150 shares/s of throughput.
**Optimal parallel version** - 32 threads, 64TCS, reached ~900 shares/s, which is **~6x speedup.**
There isn't really much difference (~2%) between using 8, 16 or 32 threads, since the CPU has only 4 physical (8 logical) cores. The 6x speedup instead of expected 4x may be due to Intel's hyper-threading over the 8 logical cores.

The plot below shows how throughput varies with batch size for the optimal version.
The batch sizes used, in order, were the following:
[ 2, 4, 8, 16, 25, 50, 100, 200, 400, 600, 800, 1000, 1250, 1500, 1750, 2000 ]

![32-64-64-64-parallel-input-full](https://github.com/user-attachments/assets/985ae92c-7c98-46d8-b81b-8bee997d35cd)

Legend:
- **Strong blue line** -> mean throughput from all measurements for each data point
- **Light blue area** -> Standard deviation area for each datapoint. The larger the area the more inconsistent the throughput is.
- **Red areas in top & bottom of blue area** - RTT (round trip time) standard deviation (you may ignore in this case, since requests were made locally - that's why is very small)

Some comments:
- The smaller the batch, the smaller the speedup - this is expected, as the decryption is the most time-consuming operation, and the one that benefits most from parallelization. If we decrease this, then serial part of execution is increased proportionally, thus speedup decreases (Amdahl's law)

Fixes #471 