### PR TITLE
Empty decrypt shares response

### DIFF
--- a/Log.h
+++ b/Log.h
@@ -86,7 +86,7 @@ public:
 // if uknown error, the error is 10000 + line number
 
 #define INIT_RESULT(__RESULT__)                                                \
-  Json::Value __RESULT__;                                                      \
+  Json::Value __RESULT__(Json::objectValue);                                   \
   int errStatus = -1 * (10000 + __LINE__);                                     \
   boost::ignore_unused(errStatus);                                             \
   string errMsg(BUF_LEN, '\0');                                                \

--- a/SGXWalletServer.cpp
+++ b/SGXWalletServer.cpp
@@ -1114,6 +1114,8 @@ Json::Value SGXWalletServer::getDecryptionSharesImpl(
     const std::string &blsKeyName, const Json::Value &publicDecryptionValues) {
   spdlog::trace("Entering {}", __FUNCTION__);
   INIT_RESULT(result)
+  // init as empty array
+  result["decryptionShares"] = Json::Value(Json::arrayValue);
 
   try {
     CHECK_STATE(checkName(blsKeyName, "BLS_KEY"));

--- a/docs/common/api-format-spec.md
+++ b/docs/common/api-format-spec.md
@@ -647,7 +647,7 @@ Returns an empty array in case the request has no shares to decrypt.
 curl -X POST --data '{ 
     "jsonrpc": "2.0", 
     "id": 1, 
-    "method": "getServerStatus", 
+    "method": "getDecryptionShares", 
     "params": {
         "blsKeyName": "BLS_KEY:SCHAIN_ID:85648391426096427994207177239552943688036003763889870037478700400929584288519:NODE_ID:1:DKG_ID:0",
         "publicDecryptionValues": [

--- a/docs/common/api-format-spec.md
+++ b/docs/common/api-format-spec.md
@@ -631,12 +631,16 @@ curl -X POST --data '{
 ## `getDecryptionShares`
 
 #### Description
-Returns the current server status.
+
+Decrypts each encoded G2 point sent within the `publicDecryptionValues` array, using the key associated with the name passed by `blsKeyName`. Returns a new array with all the decription shares.
+
+Returns an empty array in case the request has no shares to decrypt.
 
 #### Request Parameters
 | **Parameter** | **Type**   | **Description**   | **Example value**  |
 |---------------|------------|------------------------------------------|--------------|
-| `publicDecryptionValues`    | `Array`     | Array of elements, where each element represents the U component (G2 point) from the ciphertext, encoded as a [string encoded point](#6-string-encoded-point). The array can be of any size (up to MAX_INT size) | `ABC12345667ADAF...` up to 256 characters (only hexadecimal)  |
+| `blsKeyName`    | `String`     | [See BLS Key Name](#1-bls-key-name)  | `BLS_KEY:SCHAIN_ID:8564839...` |
+| `publicDecryptionValues`    | `Array<String>`     | Array of elements, where each element represents the U component (G2 point) from the ciphertext, encoded as a [string encoded point](#6-string-encoded-point). The array can be of any size (up to MAX_INT size) | `ABC12345667ADAF...` up to 256 characters (only hexadecimal)  |
 
 #### Example Request
 ```bash
@@ -645,6 +649,7 @@ curl -X POST --data '{
     "id": 1, 
     "method": "getServerStatus", 
     "params": {
+        "blsKeyName": "BLS_KEY:SCHAIN_ID:85648391426096427994207177239552943688036003763889870037478700400929584288519:NODE_ID:1:DKG_ID:0",
         "publicDecryptionValues": [
             "9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f",
             "9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f9f3a7d1cbe84f2a6d5e091b8c74e3a5f"
@@ -675,7 +680,7 @@ curl -X POST --data '{
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         ],
         "failedRequests": {
-            "1": 102,
+            "1": 1, // idx 1 has status code 1 -> bad point
         }
     }
 }

--- a/testw.cpp
+++ b/testw.cpp
@@ -1547,6 +1547,28 @@ const std::vector<int> BATCH_TEST_VALUES = {
     2 * ENCLAVE_MAX_CIPHERTEXT_BATCH,
     3 * ENCLAVE_MAX_CIPHERTEXT_BATCH};
 
+TEST_CASE_METHOD(TestFixture,
+                 "Test decryption share for empty threshold encryption",
+                 "[te-empty-decryption-share]") {
+  HttpClient client(RPC_ENDPOINT);
+  client.SetTimeout(5000);
+  StubClient c(client, JSONRPC_CLIENT_V2);
+
+  std::string key_str =
+      "0xe632f7fde2c90a073ec43eaa90dca7b82476bf28815450a11191484934b9c3f";
+  std::string name = "BLS_KEY:SCHAIN_ID:123456789:NODE_ID:0:DKG_ID:0";
+  c.importBLSKeyShare(key_str, name);
+
+  Json::Value publicDecryptionValues;
+  publicDecryptionValues["publicDecryptionValues"] = Json::arrayValue;
+  auto decryptionShares = c.getDecryptionShares(name, publicDecryptionValues);
+
+  REQUIRE(decryptionShares.isObject());
+  REQUIRE(decryptionShares.isMember("decryptionShares"));
+  REQUIRE(decryptionShares["decryptionShares"].isArray());
+  REQUIRE(decryptionShares["decryptionShares"].empty());
+}
+
 TEST_CASE_METHOD(TestFixture, "Test decryption share for threshold encryption",
                  "[te-decryption-share]") {
   HttpClient client(RPC_ENDPOINT);
@@ -1578,6 +1600,10 @@ TEST_CASE_METHOD(TestFixture, "Test decryption share for threshold encryption",
 
     auto decryptionShares = c.getDecryptionShares(name, publicDecryptionValues);
 
+    REQUIRE(decryptionShares.isObject());
+    // should have no failed requests
+    REQUIRE(!decryptionShares.isMember("failedRequests"));
+
     for (int i = 0; i < num_requests; i++) {
       auto decryption_share =
           decryptionShares["decryptionShares"][i].asString();
@@ -1585,6 +1611,100 @@ TEST_CASE_METHOD(TestFixture, "Test decryption share for threshold encryption",
       REQUIRE(share == key * decryption_values[i]);
     }
   }
+}
+
+TEST_CASE_METHOD(TestFixture, "Test decryption share for faulty shares",
+                 "[te-decryption-share-error]") {
+  HttpClient client(RPC_ENDPOINT);
+  client.SetTimeout(5000);
+  StubClient c(client, JSONRPC_CLIENT_V2);
+
+  std::string key_str =
+      "0xe632f7fde2c90a073ec43eaa90dca7b82476bf28815450a11191484934b9c3f";
+  std::string name = "BLS_KEY:SCHAIN_ID:123456789:NODE_ID:0:DKG_ID:0";
+  c.importBLSKeyShare(key_str, name);
+
+  Json::Value publicDecryptionValues;
+  publicDecryptionValues["publicDecryptionValues"][0] =
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "0000000000000000000000000000000000000000";
+  auto decryptionShares = c.getDecryptionShares(name, publicDecryptionValues);
+
+  REQUIRE(decryptionShares.isObject());
+  REQUIRE(decryptionShares.isMember("decryptionShares"));
+  REQUIRE(decryptionShares["decryptionShares"].isArray());
+  // response should also be all 0's
+  REQUIRE(decryptionShares["decryptionShares"][0] ==
+          publicDecryptionValues["publicDecryptionValues"][0]);
+
+  // check for failed requests status code
+  REQUIRE(decryptionShares.isMember("failedRequests"));
+  REQUIRE(decryptionShares["failedRequests"].isObject());
+  REQUIRE(decryptionShares["failedRequests"].isMember("0"));
+  REQUIRE(decryptionShares["failedRequests"]["0"].isInt());
+  REQUIRE(decryptionShares["failedRequests"]["0"].asInt() ==
+          STATUS_G2_NOT_WELL_FORMED);
+}
+
+TEST_CASE_METHOD(TestFixture,
+                 "Test decryption share for empty threshold encryption via zmq",
+                 "[te-empty-decryption-share-zmq]") {
+  auto client = make_shared<ZMQClient>(ZMQ_IP, ZMQ_PORT, true,
+                                       "./sgx_data/cert_data/rootCA.pem",
+                                       "./sgx_data/cert_data/rootCA.key");
+
+  std::string key_str =
+      "0xe632f7fde2c90a073ec43eaa90dca7b82476bf28815450a11191484934b9c3f";
+  std::string name = "BLS_KEY:SCHAIN_ID:123456789:NODE_ID:0:DKG_ID:0";
+  client->importBLSKeyShare(key_str, name);
+
+  Json::Value publicDecryptionValues(Json::objectValue);
+  publicDecryptionValues["publicDecryptionValues"] = Json::arrayValue;
+  Json::Value decryptionShares =
+      client->getDecryptionShares(name, publicDecryptionValues);
+
+  REQUIRE(decryptionShares.isObject());
+  REQUIRE(decryptionShares.isMember("decryptionShares"));
+  REQUIRE(decryptionShares["decryptionShares"].isArray());
+  REQUIRE(decryptionShares["decryptionShares"].empty());
+}
+
+TEST_CASE_METHOD(TestFixture, "Test decryption share for faulty shares via zmq",
+                 "[te-decryption-share-error-zmq]") {
+  auto client = make_shared<ZMQClient>(ZMQ_IP, ZMQ_PORT, true,
+                                       "./sgx_data/cert_data/rootCA.pem",
+                                       "./sgx_data/cert_data/rootCA.key");
+
+  std::string key_str =
+      "0xe632f7fde2c90a073ec43eaa90dca7b82476bf28815450a11191484934b9c3f";
+  std::string name = "BLS_KEY:SCHAIN_ID:123456789:NODE_ID:0:DKG_ID:0";
+  client->importBLSKeyShare(key_str, name);
+
+  Json::Value publicDecryptionValues;
+  publicDecryptionValues["publicDecryptionValues"][0] =
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "000000000000000000000000000000000000000000000000000000000000000000000000"
+      "0000000000000000000000000000000000000000";
+  auto decryptionShares =
+      client->getDecryptionShares(name, publicDecryptionValues);
+
+  REQUIRE(decryptionShares.isObject());
+  REQUIRE(decryptionShares.isMember("decryptionShares"));
+  REQUIRE(decryptionShares["decryptionShares"].isArray());
+  // response should also be all 0's
+  REQUIRE(decryptionShares["decryptionShares"][0] ==
+          publicDecryptionValues["publicDecryptionValues"][0]);
+
+  // check for failed requests status code
+  REQUIRE(decryptionShares.isMember("failedRequests"));
+  REQUIRE(decryptionShares["failedRequests"].isObject());
+  REQUIRE(decryptionShares["failedRequests"].isMember("0"));
+  REQUIRE(decryptionShares["failedRequests"]["0"].isInt());
+  REQUIRE(decryptionShares["failedRequests"]["0"].asInt() ==
+          STATUS_G2_NOT_WELL_FORMED);
 }
 
 TEST_CASE_METHOD(TestFixture,
@@ -1620,8 +1740,13 @@ TEST_CASE_METHOD(TestFixture,
     auto decryptionShares =
         client->getDecryptionShares(name, publicDecryptionValues);
 
+    REQUIRE(decryptionShares.isObject());
+    // should have no failed requests
+    REQUIRE(!decryptionShares.isMember("failedRequests"));
+
     for (int i = 0; i < num_requests; i++) {
-      auto decryption_share = decryptionShares[i].asString();
+      auto decryption_share =
+          decryptionShares["decryptionShares"][i].asString();
       libff::alt_bn128_G2 share = convertStringToG2(decryption_share);
       REQUIRE(share == key * decryption_values[i]);
     }

--- a/zmq_src/RspMessage.h
+++ b/zmq_src/RspMessage.h
@@ -222,7 +222,20 @@ public:
 
   virtual Json::Value process();
 
-  Json::Value getShare() { return getJsonValueRapid("decryptionShares"); }
+  Json::Value getResponse() {
+    auto decryptionShares = getJsonValueRapid("decryptionShares");
+    auto failedRequests =
+        getJsonValueRapid("failedRequests", /* optional = */ true);
+
+    Json::Value result(Json::objectValue);
+    result["decryptionShares"] = decryptionShares;
+    if (!failedRequests.isNull()) {
+      result["failedRequests"] = failedRequests;
+    }
+    return result;
+  }
+
+  Json::Value getFailedRequests() {}
 };
 
 class generateBLSPrivateKeyRspMessage : public ZMQMessage {

--- a/zmq_src/ZMQClient.cpp
+++ b/zmq_src/ZMQClient.cpp
@@ -537,7 +537,7 @@ ZMQClient::getDecryptionShares(const string &blsKeyName,
       dynamic_pointer_cast<GetDecryptionShareRspMessage>(doRequestReply(p));
   CHECK_STATE(result);
   CHECK_STATE(result->getStatus() == 0);
-  return result->getShare();
+  return result->getResponse();
 }
 
 bool ZMQClient::generateBLSPrivateKey(const string &blsKeyName) {

--- a/zmq_src/ZMQMessage.cpp
+++ b/zmq_src/ZMQMessage.cpp
@@ -43,18 +43,29 @@ uint64_t ZMQMessage::getInt64Rapid(const char *_name) {
 };
 
 Json::Value ZMQMessage::getJsonValueRapid(const char *_name) {
+  return getJsonValueRapid(_name, false);
+}
+
+Json::Value ZMQMessage::getJsonValueRapid(const char *_name, bool optional) {
   CHECK_STATE(_name);
-  CHECK_STATE(d->HasMember(_name));
-  const rapidjson::Value &a = (*d)[_name];
-
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  a.Accept(writer);
-  std::string strRequest = buffer.GetString();
-
-  Json::Reader reader;
   Json::Value root;
-  reader.parse(strRequest, root, false);
+  bool fieldIsPresent = d->HasMember(_name);
+
+  if (!optional) {
+    CHECK_STATE(fieldIsPresent);
+  }
+
+  if (fieldIsPresent) {
+    const rapidjson::Value &a = (*d)[_name];
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    a.Accept(writer);
+    std::string strRequest = buffer.GetString();
+
+    Json::Reader reader;
+    reader.parse(strRequest, root, false);
+  }
 
   return root;
 }

--- a/zmq_src/ZMQMessage.h
+++ b/zmq_src/ZMQMessage.h
@@ -178,6 +178,14 @@ public:
 
   Json::Value getJsonValueRapid(const char *_name);
 
+  /**
+   * Builds a Json::Value from the rapidjson::Document.
+   * Fetches the value of the given name from the document and returns it as a
+   * Json::Value. If field is optional, may return an empty Json::Value if the
+   * field is not present.
+   */
+  Json::Value getJsonValueRapid(const char *_name, bool optional);
+
   bool getBoolRapid(const char *_name);
 
   uint64_t getStatus() { return getInt64Rapid("status"); }


### PR DESCRIPTION
### Description

- Added empty array for `decryptionShares` as default response -> in case the request does not come with any shares to decrypt
- Updated zmq response format to include both `decryptionShares` and `failedRequests` in case of failed requests

### Tests

- Added tests for empty decryptionShares
- Added tests for faulty shares & check for expected failure status code

Fixes #474