### PR TITLE
Fix UB at startup

### DIFF
--- a/CSRManagerServer.cpp
+++ b/CSRManagerServer.cpp
@@ -118,8 +118,8 @@ Json::Value CSRManagerServer::signByHash(const string &hash, int status) {
 
 void CSRManagerServer::initCSRManagerServer() {
   constexpr bool validateClient = false;
-  hs3 =
-      make_shared<jsonrpc::HttpServer>(BASE_PORT + 2, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
+  hs3 = make_shared<jsonrpc::HttpServer>(
+      BASE_PORT + 2, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
   hs3->BindLocalhost();
   cs = make_shared<CSRManagerServer>(
       *hs3, JSONRPC_SERVER_V2); // server (json-rpc 2.0)

--- a/CSRManagerServer.cpp
+++ b/CSRManagerServer.cpp
@@ -117,7 +117,9 @@ Json::Value CSRManagerServer::signByHash(const string &hash, int status) {
 }
 
 void CSRManagerServer::initCSRManagerServer() {
-  hs3 = make_shared<jsonrpc::HttpServer>(BASE_PORT + 2);
+  constexpr bool validateClient = false;
+  hs3 =
+      make_shared<jsonrpc::HttpServer>(BASE_PORT + 2, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
   hs3->BindLocalhost();
   cs = make_shared<CSRManagerServer>(
       *hs3, JSONRPC_SERVER_V2); // server (json-rpc 2.0)

--- a/SGXInfoServer.cpp
+++ b/SGXInfoServer.cpp
@@ -115,7 +115,9 @@ Json::Value SGXInfoServer::isKeyExist(const string &key) {
 
 void SGXInfoServer::initInfoServer(uint32_t _logLevel, bool _autoSign,
                                    bool _checkCerts, bool _generateTestKeys) {
-  httpServer = make_shared<HttpServer>(BASE_PORT + 4);
+  constexpr bool validateClient = false;
+  httpServer =
+      make_shared<HttpServer>(BASE_PORT + 4, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
   server = make_shared<SGXInfoServer>(
       *httpServer, JSONRPC_SERVER_V2, _logLevel, _autoSign, _checkCerts,
       _generateTestKeys); // hybrid server (json-rpc 1.0 & 2.0)

--- a/SGXInfoServer.cpp
+++ b/SGXInfoServer.cpp
@@ -116,8 +116,8 @@ Json::Value SGXInfoServer::isKeyExist(const string &key) {
 void SGXInfoServer::initInfoServer(uint32_t _logLevel, bool _autoSign,
                                    bool _checkCerts, bool _generateTestKeys) {
   constexpr bool validateClient = false;
-  httpServer =
-      make_shared<HttpServer>(BASE_PORT + 4, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
+  httpServer = make_shared<HttpServer>(
+      BASE_PORT + 4, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
   server = make_shared<SGXInfoServer>(
       *httpServer, JSONRPC_SERVER_V2, _logLevel, _autoSign, _checkCerts,
       _generateTestKeys); // hybrid server (json-rpc 1.0 & 2.0)

--- a/SGXRegistrationServer.cpp
+++ b/SGXRegistrationServer.cpp
@@ -161,8 +161,8 @@ Json::Value SGXRegistrationServer::GetCertificate(const string &hash) {
 
 void SGXRegistrationServer::initRegistrationServer(bool _autoSign) {
   constexpr bool validateClient = false;
-  httpServer =
-      make_shared<HttpServer>(BASE_PORT + 1, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
+  httpServer = make_shared<HttpServer>(
+      BASE_PORT + 1, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
 
   server = make_shared<SGXRegistrationServer>(
       *httpServer, JSONRPC_SERVER_V2,

--- a/SGXRegistrationServer.cpp
+++ b/SGXRegistrationServer.cpp
@@ -160,7 +160,10 @@ Json::Value SGXRegistrationServer::GetCertificate(const string &hash) {
 }
 
 void SGXRegistrationServer::initRegistrationServer(bool _autoSign) {
-  httpServer = make_shared<HttpServer>(BASE_PORT + 1);
+  constexpr bool validateClient = false;
+  httpServer =
+      make_shared<HttpServer>(BASE_PORT + 1, "", "", "", validateClient, DEFAULT_HTTP_SERVER_THREADS);
+
   server = make_shared<SGXRegistrationServer>(
       *httpServer, JSONRPC_SERVER_V2,
       _autoSign); // hybrid server (json-rpc 1.0 & 2.0)

--- a/sgxwallet_common.h
+++ b/sgxwallet_common.h
@@ -48,6 +48,9 @@ extern bool useHTTPS;
 extern bool enterBackupKey;
 extern bool autoconfirm;
 
+// default number of threads for http server as per libjson-rpc-cpp
+#define DEFAULT_HTTP_SERVER_THREADS 50
+
 #define BUF_LEN 4096
 
 #define ENCLAVE_MAX_CIPHERTEXT_BATCH 100


### PR DESCRIPTION
## Description

SGXWallet startup results in core dump some times - see #510

The reason is that it currently initializes some servers (CSR, Info, Registration) using default `HTTPServer` 4-arg constructor (although passes only 1 arg, the constructor sets default values for the other 3 args) - which **never sets a value for sslca, but still uses it for initializing a class member**. Thus, resulting in UB.

## Fix

- Use the complete 6-arg constructor, passing all args explicitly (including sslca)



## Tests


Tested locally, the issue does not appear anymore (after dozens of tries, when it used to appear every 3/4 tries)


Fixes #510 