### PR TITLE
set explicit dependency for release build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,27 +25,10 @@ autom4te.cache
 config.log
 config.status
 
-libBLS/deps/boost_1*
-libBLS/deps/openssl
-libBLS/deps/curl
-libBLS/deps/gmp-6.1.2
-libBLS/deps/libff
-libBLS/deps/jsoncpp
-libBLS/deps/libjson-rpc-cpp
-libBLS/deps/libjson-rpc-cpp-develop
-libBLS/deps/libmicrohttpd
-libBLS/deps/argtable2
-libBLS/deps/zlib
-libBLS/deps/deps_inst
-libBLS/deps/double-conversion
-libBLS/deps/fast_float
-libBLS/deps/fmt
-libBLS/deps/folly
-libBLS/deps/gflags-master
-libBLS/deps/glog
-libBLS/deps/libevent
-libBLS/deps/mcl
-libBLS/deps/*.tar.*
+# Ignore all inside deps/ except pre_downloaded
+libBLS/deps/*
+!libBLS/deps/pre_downloaded/
+!libBLS/deps/pre_downloaded/**
 
 linux-sgx/build/
 linux-sgx/docker/build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,15 @@ libBLS/deps/libjson-rpc-cpp-develop
 libBLS/deps/libmicrohttpd
 libBLS/deps/argtable2
 libBLS/deps/zlib
+libBLS/deps/deps_inst
+libBLS/deps/double-conversion
+libBLS/deps/fast_float
+libBLS/deps/fmt
+libBLS/deps/folly
+libBLS/deps/gflags-master
+libBLS/deps/glog
+libBLS/deps/libevent
+libBLS/deps/mcl
 libBLS/deps/*.tar.*
 
 linux-sgx/build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,8 @@ config.status
 libBLS/deps/*
 !libBLS/deps/pre_downloaded/
 !libBLS/deps/pre_downloaded/**
+!libBLS/deps/build.sh
+!libBLS/deps/clean.sh
 
 linux-sgx/build/
 linux-sgx/docker/build/

--- a/scripts/docker_build_main.sh
+++ b/scripts/docker_build_main.sh
@@ -48,6 +48,8 @@ case "${BUILD_TYPE}" in
 		touch /var/hwmode
 		./configure --with-sgx-build=release
 		cd secure_enclave
+		# Explicit target builds do not force Automake BUILT_SOURCES first.
+		make secure_enclave_t.c secure_enclave_t.h
 		make secure_enclave.so -j"${JOBS}"
 		cd /usr/src/sdk/scripts
 		./sign_enclave.bash

--- a/secure_enclave/Makefile.am
+++ b/secure_enclave/Makefile.am
@@ -90,6 +90,11 @@ secure_enclave_SOURCES = secure_enclave_t.c secure_enclave_t.h \
         DKGUtils.cpp TEUtils.cpp EnclaveCommon.cpp DomainParameters.cpp MclUtils.cpp \
         $(ENCLAVE_KEY) $(ENCLAVE_CONFIG)
 
+# Direct "make secure_enclave.so" builds can bypass BUILT_SOURCES ordering.
+# Force explicit dependency on the targets below
+secure_enclave.$(OBJEXT): secure_enclave_t.h
+EnclaveCommon.$(OBJEXT): secure_enclave_t.h
+
 
 ## Add additional linker flags to AM_LDFLAGS here. Don't put
 ## libraries flags here (see below).


### PR DESCRIPTION
## Description

Set explicit dependencies on `secure_enclave_t.c` and `secure_enclave_t.h` and force building them before building `secure_enclave.so`:

```bash
# Explicit target builds do not force Automake BUILT_SOURCES first.
make secure_enclave_t.c secure_enclave_t.h
make secure_enclave.so -j"${JOBS}"
```

Only happens in release build. other builds don't specify specific build target, and simply run `make -j"${JOBS}` which already respects dependencies.

Fixes #519 (see issue description)